### PR TITLE
Issue #143: Added dbh>=1.0 filter on FVS created trees

### DIFF
--- a/src/uc_fvs_output.cs
+++ b/src/uc_fvs_output.cs
@@ -4331,7 +4331,7 @@ namespace FIA_Biosum_Manager
                                                    "'" + m_strDateTimeCreated + "' AS DateTimeCreated " +
                                                    "INTO cutlist_fvs_created_seedlings_work_table " +
                                                    "FROM " + strCasesTable + " c," + strFVSOutTableLink + " t " +
-                                                   "WHERE c.CaseID = t.CaseID AND MID(t.treeid, 1, 2) = 'ES' AND dbh >= 1.0"; //t.dbh?
+                                                   "WHERE c.CaseID = t.CaseID AND MID(t.treeid, 1, 2) = 'ES' AND dbh >= 1.0";
                                             }
                                             else
                                             {
@@ -4353,7 +4353,7 @@ namespace FIA_Biosum_Manager
                                                    "FROM " + strCasesTable + " c," + strFVSOutTableLink + " t,cutlist_rowid_work_table r " +
                                                    "WHERE c.CaseID = t.CaseID AND MID(t.treeid, 1, 2) = 'ES' AND " + 
                                                          "(r.CaseId = t.CaseId AND r.StandId = t.StandId AND r.year = t.year AND r.treeid = t.treeid AND r.treeindex = t.treeindex) AND " + 
-                                                         "(r.CaseId = c.CaseId) AND dbh >= 1.0"; //t.dbh?
+                                                         "(r.CaseId = c.CaseId) AND dbh >= 1.0";
                                             }
 
                                             if (m_bDebug && frmMain.g_intDebugLevel > 2)

--- a/src/uc_fvs_output.cs
+++ b/src/uc_fvs_output.cs
@@ -4270,7 +4270,7 @@ namespace FIA_Biosum_Manager
                                                                         "(SELECT standid,year " +
                                                                          "FROM " + strFVSOutSeqNumMatrixTableLink + " " +
                                                                          "WHERE CYCLE" + strCycle + "_PRE_YN='Y')  b " +
-                                                                    "WHERE TRIM(a.biosum_cond_id)=TRIM(b.standid) AND CINT(a.rxyear)=b.year";
+                                                                    "WHERE TRIM(a.biosum_cond_id)=TRIM(b.standid) AND CINT(a.rxyear)=b.year AND a.dbh >= 1.0";
 
                                             if (m_bDebug && frmMain.g_intDebugLevel > 2)
                                                 this.WriteText(m_strDebugFile, "START: " + System.DateTime.Now.ToString() + "\r\n" + oAdo.m_strSQL + "\r\n");
@@ -4287,7 +4287,7 @@ namespace FIA_Biosum_Manager
                                                                         "(SELECT standid,year " +
                                                                          "FROM " + strFVSOutSeqNumMatrixTableLink + " " +
                                                                          "WHERE CYCLE" + strCycle + "_PRE_YN='Y')  b " +
-                                                                    "WHERE TRIM(a.biosum_cond_id)=TRIM(b.standid) AND CINT(a.rxyear)=b.year";
+                                                                    "WHERE TRIM(a.biosum_cond_id)=TRIM(b.standid) AND CINT(a.rxyear)=b.year AND a.dbh >= 1.0";
 
                                             if (m_bDebug && frmMain.g_intDebugLevel > 2)
                                                 this.WriteText(m_strDebugFile, "START: " + System.DateTime.Now.ToString() + "\r\n" + oAdo.m_strSQL + "\r\n");

--- a/src/uc_fvs_output.cs
+++ b/src/uc_fvs_output.cs
@@ -4270,7 +4270,7 @@ namespace FIA_Biosum_Manager
                                                                         "(SELECT standid,year " +
                                                                          "FROM " + strFVSOutSeqNumMatrixTableLink + " " +
                                                                          "WHERE CYCLE" + strCycle + "_PRE_YN='Y')  b " +
-                                                                    "WHERE TRIM(a.biosum_cond_id)=TRIM(b.standid) AND CINT(a.rxyear)=b.year AND a.dbh >= 1.0";
+                                                                    "WHERE TRIM(a.biosum_cond_id)=TRIM(b.standid) AND CINT(a.rxyear)=b.year";
 
                                             if (m_bDebug && frmMain.g_intDebugLevel > 2)
                                                 this.WriteText(m_strDebugFile, "START: " + System.DateTime.Now.ToString() + "\r\n" + oAdo.m_strSQL + "\r\n");
@@ -4287,7 +4287,7 @@ namespace FIA_Biosum_Manager
                                                                         "(SELECT standid,year " +
                                                                          "FROM " + strFVSOutSeqNumMatrixTableLink + " " +
                                                                          "WHERE CYCLE" + strCycle + "_PRE_YN='Y')  b " +
-                                                                    "WHERE TRIM(a.biosum_cond_id)=TRIM(b.standid) AND CINT(a.rxyear)=b.year AND a.dbh >= 1.0";
+                                                                    "WHERE TRIM(a.biosum_cond_id)=TRIM(b.standid) AND CINT(a.rxyear)=b.year";
 
                                             if (m_bDebug && frmMain.g_intDebugLevel > 2)
                                                 this.WriteText(m_strDebugFile, "START: " + System.DateTime.Now.ToString() + "\r\n" + oAdo.m_strSQL + "\r\n");
@@ -4310,7 +4310,7 @@ namespace FIA_Biosum_Manager
                                         oAdo.m_strSQL = "SELECT COUNT(*) FROM " +
                                                          "(SELECT TOP 1 c.standid " +
                                                           "FROM " + strCasesTable + " c," + strFVSOutTableLink + " t " +
-                                                          "WHERE c.CaseID = t.CaseID AND MID(t.treeid, 1, 2) = 'ES')";
+                                                          "WHERE c.CaseID = t.CaseID AND MID(t.treeid, 1, 2) = 'ES' AND t.dbh >= 1.0)";
                                         if ((int)oAdo.getRecordCount(oConn, oAdo.m_strSQL, "temp") > 0)
                                         {
                                             if (bIdColumnExist)
@@ -4331,7 +4331,7 @@ namespace FIA_Biosum_Manager
                                                    "'" + m_strDateTimeCreated + "' AS DateTimeCreated " +
                                                    "INTO cutlist_fvs_created_seedlings_work_table " +
                                                    "FROM " + strCasesTable + " c," + strFVSOutTableLink + " t " +
-                                                   "WHERE c.CaseID = t.CaseID AND MID(t.treeid, 1, 2) = 'ES'";
+                                                   "WHERE c.CaseID = t.CaseID AND MID(t.treeid, 1, 2) = 'ES' AND dbh >= 1.0"; //t.dbh?
                                             }
                                             else
                                             {
@@ -4353,7 +4353,7 @@ namespace FIA_Biosum_Manager
                                                    "FROM " + strCasesTable + " c," + strFVSOutTableLink + " t,cutlist_rowid_work_table r " +
                                                    "WHERE c.CaseID = t.CaseID AND MID(t.treeid, 1, 2) = 'ES' AND " + 
                                                          "(r.CaseId = t.CaseId AND r.StandId = t.StandId AND r.year = t.year AND r.treeid = t.treeid AND r.treeindex = t.treeindex) AND " + 
-                                                         "(r.CaseId = c.CaseId)";
+                                                         "(r.CaseId = c.CaseId) AND dbh >= 1.0"; //t.dbh?
                                             }
 
                                             if (m_bDebug && frmMain.g_intDebugLevel > 2)
@@ -4402,7 +4402,7 @@ namespace FIA_Biosum_Manager
                                         oAdo.m_strSQL = "SELECT COUNT(*) FROM " +
                                                         "(SELECT TOP 1 c.standid " +
                                                          "FROM " + strCasesTable + " c," + strFVSOutTableLink + " t " +
-                                                         "WHERE c.CaseID = t.CaseID AND MID(t.treeid, 1, 2) = 'CM')";
+                                                         "WHERE c.CaseID = t.CaseID AND MID(t.treeid, 1, 2) = 'CM' AND t.dbh >= 1.0)";
                                         if ((int)oAdo.getRecordCount(oConn, oAdo.m_strSQL, "temp") > 0)
                                         {
                                             //FVS CREATED CO
@@ -4423,7 +4423,7 @@ namespace FIA_Biosum_Manager
                                                    "'" + m_strDateTimeCreated + "' AS DateTimeCreated " +
                                                    "INTO cutlist_fvs_created_compacted_work_table " +
                                                    "FROM " + strCasesTable + " c," + strFVSOutTableLink + " t " +
-                                                   "WHERE c.CaseID = t.CaseID AND MID(t.treeid, 1, 2) = 'CM'";
+                                                   "WHERE c.CaseID = t.CaseID AND MID(t.treeid, 1, 2) = 'CM' AND dbh >= 1.0";
                                             }
                                             else
                                             {
@@ -4444,7 +4444,7 @@ namespace FIA_Biosum_Manager
                                                    "FROM " + strCasesTable + " c," + strFVSOutTableLink + " t,cutlist_rowid_work_table r " +
                                                    "WHERE c.CaseID = t.CaseID AND MID(t.treeid, 1, 2) = 'CM' AND " +
                                                          "(r.CaseId = t.CaseId AND r.StandId = t.StandId AND r.year = t.year AND r.treeid = t.treeid AND r.treeindex = t.treeindex) AND " +
-                                                         "(r.CaseId = c.CaseId)";
+                                                         "(r.CaseId = c.CaseId) AND dbh >= 1.0";
                                             }
 
                                             if (m_bDebug && frmMain.g_intDebugLevel > 2)


### PR DESCRIPTION
Issue #143: From @lpotts in an email chain:

Since master.tree records that will always be greater than 1 inch in diameter, we just need to apply the filter to FVS created trees.

This sql needs the filter:
```csharp
//
//FVS CREATED SEEDLING TREES
//
//make sure there are records to insert
     oAdo.m_strSQL = "SELECT COUNT(*) FROM " +
                  "(SELECT TOP 1 c.standid " +
                   "FROM " + strCasesTable + " c," + strFVSOutTableLink + " t " +
                  "WHERE c.CaseID = t.CaseID AND MID(t.treeid, 1, 2) = 'ES')";
```

Any inserts into this table need the filter:
`cutlist_fvs_created_seedlings_work_table`

This sql needs the filter:
```csharp
//
//FVS CREATED COMPACT TREES
//
//make sure there are records to insert
oAdo.m_strSQL = "SELECT COUNT(*) FROM " +
                  "(SELECT TOP 1 c.standid " +
                   "FROM " + strCasesTable + " c," + strFVSOutTableLink + " t " +
                  "WHERE c.CaseID = t.CaseID AND MID(t.treeid, 1, 2) = 'CM')";
```
Any inserts into this table need the filter.
`cutlist_fvs_created_compacted_work_table`