### PR TITLE
Issue #132 deleting conditions, generating empty fvs_cutlist, filtering year>0 in pre-processing fvsout audit

### DIFF
--- a/src/Queries.cs
+++ b/src/Queries.cs
@@ -1295,13 +1295,13 @@ namespace FIA_Biosum_Manager
                 strSQL[0] = "SELECT COUNT(*) AS TREECOUNT, STANDID,YEAR " +
                             "INTO " + p_strIntoTempTreeListTableName + " " +
                             "FROM " + p_strTreeListTableName + " " +
-                            "WHERE standid IS NOT NULL " +
+                            "WHERE standid IS NOT NULL and year > 0 " +
                             "GROUP BY CASEID,STANDID,YEAR";
 
                 strSQL[1] = "SELECT DISTINCT STANDID,YEAR " +
                             "INTO " + p_strIntoTempSummaryTableName + " " +
                             "FROM " + p_strSummaryTableName + " " +
-                            "WHERE standid IS NOT NULL";
+                            "WHERE standid IS NOT NULL and year > 0 ";
 
                 strSQL[2] = "SELECT a.STANDID,a.YEAR,a.TREECOUNT, " + 
                               "SUM(IIF(a.standid=b.standid AND a.year=b.year,1,0)) AS ROWCOUNT " + 

--- a/src/Queries.cs
+++ b/src/Queries.cs
@@ -3280,7 +3280,7 @@ namespace FIA_Biosum_Manager
                     }
 
 
-                    public static string SetInferredSaplingDbh(string strDestTable)
+                    public static string SetInferredSeedlingDbh(string strDestTable)
                     {
                         return "UPDATE " + strDestTable +
                                " SET Dbh=0.1 WHERE Tree_Count > 25 AND Dbh <= 0 AND History=1;";

--- a/src/Tables.cs
+++ b/src/Tables.cs
@@ -1752,6 +1752,49 @@ namespace FIA_Biosum_Manager
 			public FVS()
 			{
 			}
+
+		    public static void CreateFVSCutListTable(ado_data_access p_oAdo)
+		    {
+		        p_oAdo.SqlNonQuery(p_oAdo.m_OleDbConnection, CreateFVSCutListTableSQL());
+		    }
+
+		    public static string CreateFVSCutListTableSQL()
+		    {
+		        return "CREATE TABLE FVS_CutList " +
+		            "(CaseID CHAR(255)," +
+		            "StandID CHAR(255)," +
+                    "`Year` LONG," +
+                    "PrdLen LONG," +
+		            "TreeId CHAR(255)," +
+                    "TreeIndex LONG," +
+		            "Species CHAR(255)," +
+                    "TreeVal LONG," +
+                    "SSCD LONG," +
+                    "PtIndex LONG," +
+		            "TPA DOUBLE," +
+		            "MortPA DOUBLE," +
+		            "DBH DOUBLE," +
+		            "DG DOUBLE," +
+		            "Ht DOUBLE," +
+		            "HtG DOUBLE," +
+                    "PctCr LONG," +
+		            "CrWidth DOUBLE," +
+                    "MistCD LONG," +
+		            "BAPctile DOUBLE," +
+		            "PtBAL DOUBLE," +
+		            "TCuFt DOUBLE," +
+		            "MCuFt DOUBLE," +
+		            "BdFt DOUBLE," +
+                    "MDefect LONG," +
+                    "BDefect LONG," +
+                    "TruncHt LONG," +
+		            "EstHt DOUBLE," +
+                    "ActPt LONG," +
+		            "Ht2TDCF SINGLE," +
+		            "Ht2TDBF SINGLE," +
+		            "TreeAge DOUBLE)";
+		    }
+
 			//
 			//FVS_tree table
 			//

--- a/src/ado_data_access.cs
+++ b/src/ado_data_access.cs
@@ -483,71 +483,116 @@ namespace FIA_Biosum_Manager
         /// </summary>
         /// <param name="p_oConn"></param>
         /// <returns></returns>
-		public string[] getTableNames(System.Data.OleDb.OleDbConnection p_oConn)
-		{
-			string strDelimiter = ",";
-			string strTables="";
-			DataTable tables = p_oConn.GetOleDbSchemaTable(System.Data.OleDb.OleDbSchemaGuid.Tables_Info,new object[]{null,null,null,null});
-			int x=0;
-			foreach(DataRow row in tables.Rows) 
-			{
-				if (row["table_name"]!=System.DBNull.Value)
-				{
-					if (Convert.ToString(row["table_name"]).ToUpper().IndexOf("MSYS") < 0)
-					{
-						if (Convert.ToString(row["table_type"]).Trim().ToUpper() == 
-							"TABLE" || 
-							Convert.ToString(row["table_type"]).Trim().ToUpper() == 
-							"LINK") // || 
-						{
-							strTables = strTables + Convert.ToString(row["table_name"]) + ",";
-							x++;
-						}
-					}
-				}
-				
-			}
-			if (strTables.Trim().Length > 0) strTables=strTables.Substring(0,strTables.Length-1);
+        public string[] getTableNames(System.Data.OleDb.OleDbConnection p_oConn)
+        {
+            string strDelimiter = ",";
+            string strTables = "";
+            DataTable tables = p_oConn.GetOleDbSchemaTable(System.Data.OleDb.OleDbSchemaGuid.Tables_Info,
+                new object[] {null, null, null, null});
+            int x = 0;
+            foreach (DataRow row in tables.Rows)
+            {
+                if (row["table_name"] != System.DBNull.Value)
+                {
+                    if (Convert.ToString(row["table_name"]).ToUpper().IndexOf("MSYS") < 0)
+                    {
+                        if (Convert.ToString(row["table_type"]).Trim().ToUpper() == "TABLE" ||
+                            Convert.ToString(row["table_type"]).Trim().ToUpper() == "LINK" ||
+                            Convert.ToString(row["table_type"]).Trim().ToUpper() == "PASS-THROUGH")
+                        {
+                            strTables = strTables + Convert.ToString(row["table_name"]) + ",";
+                            x++;
+                        }
+                    }
+                }
+            }
+            if (strTables.Trim().Length > 0) strTables = strTables.Substring(0, strTables.Length - 1);
 
-			string[] strTablesArray = strTables.Split(strDelimiter.ToCharArray());
-			
-			return strTablesArray;
-		}
+            string[] strTablesArray = strTables.Split(strDelimiter.ToCharArray());
+
+            return strTablesArray;
+        }
+
+
+        /// <summary>
+        /// Get the table names (excluding linked tables) contained in the MS Access database file connection
+        /// </summary>
+        /// <param name="p_oConn"></param>
+        /// <returns></returns>
+        public string[] getTableNamesOfSpecificTypes(System.Data.OleDb.OleDbConnection p_oConn, bool includeRegularTables = true, bool includeLinkedTables = false, bool includePassThroughTables = false)
+        {
+            string strDelimiter = ",";
+            string strTables = "";
+            DataTable tables = p_oConn.GetOleDbSchemaTable(System.Data.OleDb.OleDbSchemaGuid.Tables_Info,
+                new object[] {null, null, null, null});
+            int x = 0;
+            foreach (DataRow row in tables.Rows)
+            {
+                if (row["table_name"] != System.DBNull.Value)
+                {
+                    if (Convert.ToString(row["table_name"]).ToUpper().IndexOf("MSYS") < 0)
+                    {
+                        if (includeRegularTables && Convert.ToString(row["table_type"]).Trim().ToUpper() ==
+                            "TABLE")
+                        {
+                            strTables = strTables + Convert.ToString(row["table_name"]) + ",";
+                            x++;
+                        }
+                        else if (includeLinkedTables && Convert.ToString(row["table_type"]).Trim().ToUpper() ==
+                            "LINK")
+                        {
+                            strTables = strTables + Convert.ToString(row["table_name"]) + ",";
+                            x++;
+                        }
+                        else if (includePassThroughTables && Convert.ToString(row["table_type"]).Trim().ToUpper() ==
+                            "PASS-THROUGH")
+                        {
+                            strTables = strTables + Convert.ToString(row["table_name"]) + ",";
+                            x++;
+                        }
+                    }
+                }
+            }
+            if (strTables.Trim().Length > 0) strTables = strTables.Substring(0, strTables.Length - 1);
+            string[] strTablesArray = strTables.Split(strDelimiter.ToCharArray());
+            return strTablesArray;
+        }
+
+
         /// <summary>
         /// Check if the table exists in the MS Access database file
         /// </summary>
         /// <param name="p_oConn"></param>
         /// <param name="p_strTableName"></param>
         /// <returns></returns>
-		public bool TableExist(System.Data.OleDb.OleDbConnection p_oConn,string p_strTableName)
-		{
-			
-			DataTable tables = p_oConn.GetOleDbSchemaTable(System.Data.OleDb.OleDbSchemaGuid.Tables_Info,new object[]{null,null,null,null});
-			bool bFound=false;
-			foreach(DataRow row in tables.Rows) 
-			{
-				if (row["table_name"]!=System.DBNull.Value)
-				{
-					if (Convert.ToString(row["table_name"]).ToUpper().IndexOf("MSYS") < 0)
-					{
-						if (Convert.ToString(row["table_type"]).Trim().ToUpper() == 
-							"TABLE" || 
-							Convert.ToString(row["table_type"]).Trim().ToUpper() == 
-							"LINK")
-						{
-							if (Convert.ToString(row["table_name"]).Trim().ToUpper() == 
-								p_strTableName.Trim().ToUpper())
-							{
-								bFound=true;
-								break;
-							}
-						}
-					}
-				}
-			}
-			tables.Dispose();
-			return bFound;
-		}
+        public bool TableExist(System.Data.OleDb.OleDbConnection p_oConn, string p_strTableName)
+        {
+            DataTable tables = p_oConn.GetOleDbSchemaTable(System.Data.OleDb.OleDbSchemaGuid.Tables_Info,
+                new object[] {null, null, null, null});
+            bool bFound = false;
+            foreach (DataRow row in tables.Rows)
+            {
+                if (row["table_name"] != System.DBNull.Value)
+                {
+                    if (Convert.ToString(row["table_name"]).ToUpper().IndexOf("MSYS") < 0)
+                    {
+                        if (Convert.ToString(row["table_type"]).Trim().ToUpper() == "TABLE" ||
+                            Convert.ToString(row["table_type"]).Trim().ToUpper() == "LINK" ||
+                            Convert.ToString(row["table_type"]).Trim().ToUpper() == "PASS-THROUGH")
+                        {
+                            if (Convert.ToString(row["table_name"]).Trim().ToUpper() ==
+                                p_strTableName.Trim().ToUpper())
+                            {
+                                bFound = true;
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+            tables.Dispose();
+            return bFound;
+        }
         /// <summary>
         /// Check if the table exists in the MS Access database file
         /// </summary>

--- a/src/fia_biosum.csproj
+++ b/src/fia_biosum.csproj
@@ -165,6 +165,12 @@
     <Compile Include="btnMainForm.cs">
       <SubType>Component</SubType>
     </Compile>
+    <Compile Include="uc_delete_conditions.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="uc_delete_conditions.Designer.cs">
+      <DependentUpon>uc_delete_conditions.cs</DependentUpon>
+    </Compile>
     <Compile Include="uc_textboxWithButtons.cs">
       <SubType>UserControl</SubType>
     </Compile>
@@ -591,6 +597,9 @@
     <Content Include="table-select-row-icon.png" />
     <EmbeddedResource Include="btnMainForm.resx">
       <DependentUpon>btnMainForm.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="uc_delete_conditions.resx">
+      <DependentUpon>uc_delete_conditions.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="uc_textboxWithButtons.resx">
       <DependentUpon>uc_textboxWithButtons.cs</DependentUpon>

--- a/src/frmDialog.cs
+++ b/src/frmDialog.cs
@@ -34,6 +34,7 @@ namespace FIA_Biosum_Manager
 		private System.Windows.Forms.ComboBox _cmbBox;
 		public FIA_Biosum_Manager.uc_plot_add_edit uc_plot_add_edit1;
 		public FIA_Biosum_Manager.uc_plot_input uc_plot_input1;
+		public FIA_Biosum_Manager.uc_delete_conditions uc_delete_conditions;
 		public FIA_Biosum_Manager.uc_project_notes uc_project_notes1;
 		public FIA_Biosum_Manager.uc_processor_scenario_tree_diam_groups_list uc_processor_scenario_tree_diam_groups_list1;
 		public FIA_Biosum_Manager.uc_processor_scenario_tree_diam_groups_edit uc_processor_scenario_tree_diam_groups_edit1;
@@ -75,10 +76,7 @@ namespace FIA_Biosum_Manager
 		/// </summary>
 		private System.ComponentModel.Container components = null;
 
-
-		
-
-		public frmDialog()
+	    public frmDialog()
 		{
 			InitializeComponent();
             LastWindowState = this.WindowState;
@@ -263,7 +261,7 @@ namespace FIA_Biosum_Manager
                 if (this.uc_rx_list1 != null) this.ParentControl.Enabled = true;
                 if (this.uc_gis_psite1 != null) this.ParentControl.Enabled = true;
                 if (this.uc_plot_input1 != null) this.ParentControl.Enabled = true;
-                
+                if (this.uc_delete_conditions != null) this.ParentControl.Enabled = true;
                
 
 				this.Dispose();
@@ -406,6 +404,14 @@ namespace FIA_Biosum_Manager
 			this.uc_plot_input1.Visible = true;
             
 		}
+
+	    public void Initialize_Delete_Conditions_User_Control()
+	    {
+	        this.uc_delete_conditions = new uc_delete_conditions();
+            this.Controls.Add(this.uc_delete_conditions);
+	        this.uc_delete_conditions.Visible = true;
+	    }
+
 		public void Initialize_Plot_Tree_Diam_User_Control()
 		{
 

--- a/src/fvs_input.cs
+++ b/src/fvs_input.cs
@@ -666,8 +666,8 @@ namespace FIA_Biosum_Manager
                 m_ado.SqlNonQuery(m_ado.m_OleDbConnection, strSQL);
                 frmMain.g_oDelegate.SetControlPropertyValue(m_frmTherm.progressBar1, "Value", intProgressBarCounter++);
 
-                //Set Dbh to 0.1 if Tpa > 25 and dbh <= 0 and live tree (implies saplings) 
-                strSQL = Queries.FVS.FVSInput.TreeInit.SetInferredSaplingDbh(strTreeInitWorkTable);
+                //Set Dbh to 0.1 if Tpa > 25 and dbh <= 0 and live tree (implies seedlings) 
+                strSQL = Queries.FVS.FVSInput.TreeInit.SetInferredSeedlingDbh(strTreeInitWorkTable);
                 m_ado.SqlNonQuery(m_ado.m_OleDbConnection, strSQL);
                 frmMain.g_oDelegate.SetControlPropertyValue(m_frmTherm.progressBar1, "Value", intProgressBarCounter++);
 

--- a/src/uc_delete_conditions.Designer.cs
+++ b/src/uc_delete_conditions.Designer.cs
@@ -1,0 +1,453 @@
+﻿namespace FIA_Biosum_Manager
+{
+    partial class uc_delete_conditions
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(uc_delete_conditions));
+            this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.grpboxFilterByState = new System.Windows.Forms.GroupBox();
+            this.btnFilterByStateFinish = new System.Windows.Forms.Button();
+            this.btnFilterByStateUnselect = new System.Windows.Forms.Button();
+            this.btnFilterByStateSelect = new System.Windows.Forms.Button();
+            this.lstFilterByState = new System.Windows.Forms.ListView();
+            this.btnFilterByStateHelp = new System.Windows.Forms.Button();
+            this.btnFilterByStatePrevious = new System.Windows.Forms.Button();
+            this.btnFilterByStateNext = new System.Windows.Forms.Button();
+            this.btnFilterByStateCancel = new System.Windows.Forms.Button();
+            this.grpboxFilterByCondId = new System.Windows.Forms.GroupBox();
+            this.btnFilterByPlotFinish = new System.Windows.Forms.Button();
+            this.btnFilterByPlotUnselect = new System.Windows.Forms.Button();
+            this.btnFilterByPlotSelect = new System.Windows.Forms.Button();
+            this.lstFilterByCond = new System.Windows.Forms.ListView();
+            this.btnFilterByPlotHelp = new System.Windows.Forms.Button();
+            this.btnFilterByPlotPrevious = new System.Windows.Forms.Button();
+            this.btnFilterByPlotNext = new System.Windows.Forms.Button();
+            this.btnFilterByPlotCancel = new System.Windows.Forms.Button();
+            this.lblTitle = new System.Windows.Forms.Label();
+            this.grpboxFilter = new System.Windows.Forms.GroupBox();
+            this.btnFilterFinish = new System.Windows.Forms.Button();
+            this.btnFilterHelp = new System.Windows.Forms.Button();
+            this.btnFilterPrevious = new System.Windows.Forms.Button();
+            this.btnFilterNext = new System.Windows.Forms.Button();
+            this.btnFilterCancel = new System.Windows.Forms.Button();
+            this.grpboxFilterOptions = new System.Windows.Forms.GroupBox();
+            this.btnFilterByFileBrowse = new System.Windows.Forms.Button();
+            this.txtFilterByFile = new System.Windows.Forms.TextBox();
+            this.rdoFilterByFile = new System.Windows.Forms.RadioButton();
+            this.rdoFilterByMenu = new System.Windows.Forms.RadioButton();
+            this.rdoDeleteAllConds = new System.Windows.Forms.RadioButton();
+            this.groupBox1.SuspendLayout();
+            this.grpboxFilterByState.SuspendLayout();
+            this.grpboxFilterByCondId.SuspendLayout();
+            this.grpboxFilter.SuspendLayout();
+            this.grpboxFilterOptions.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // groupBox1
+            // 
+            this.groupBox1.Controls.Add(this.grpboxFilterByState);
+            this.groupBox1.Controls.Add(this.grpboxFilterByCondId);
+            this.groupBox1.Controls.Add(this.lblTitle);
+            this.groupBox1.Controls.Add(this.grpboxFilter);
+            this.groupBox1.Location = new System.Drawing.Point(0, 0);
+            this.groupBox1.Name = "groupBox1";
+            this.groupBox1.Size = new System.Drawing.Size(704, 1159);
+            this.groupBox1.TabIndex = 0;
+            this.groupBox1.TabStop = false;
+            // 
+            // grpboxFilterByState
+            // 
+            this.grpboxFilterByState.Controls.Add(this.btnFilterByStateFinish);
+            this.grpboxFilterByState.Controls.Add(this.btnFilterByStateUnselect);
+            this.grpboxFilterByState.Controls.Add(this.btnFilterByStateSelect);
+            this.grpboxFilterByState.Controls.Add(this.lstFilterByState);
+            this.grpboxFilterByState.Controls.Add(this.btnFilterByStateHelp);
+            this.grpboxFilterByState.Controls.Add(this.btnFilterByStatePrevious);
+            this.grpboxFilterByState.Controls.Add(this.btnFilterByStateNext);
+            this.grpboxFilterByState.Controls.Add(this.btnFilterByStateCancel);
+            this.grpboxFilterByState.ImeMode = System.Windows.Forms.ImeMode.Off;
+            this.grpboxFilterByState.Location = new System.Drawing.Point(16, 413);
+            this.grpboxFilterByState.Name = "grpboxFilterByState";
+            this.grpboxFilterByState.Size = new System.Drawing.Size(672, 360);
+            this.grpboxFilterByState.TabIndex = 33;
+            this.grpboxFilterByState.TabStop = false;
+            this.grpboxFilterByState.Text = "Filter By State And County";
+            // 
+            // btnFilterByStateFinish
+            // 
+            this.btnFilterByStateFinish.Location = new System.Drawing.Point(584, 325);
+            this.btnFilterByStateFinish.Name = "btnFilterByStateFinish";
+            this.btnFilterByStateFinish.Size = new System.Drawing.Size(72, 24);
+            this.btnFilterByStateFinish.TabIndex = 34;
+            this.btnFilterByStateFinish.Text = "Delete";
+            this.btnFilterByStateFinish.Click += new System.EventHandler(this.btnFilterFinish_Click);
+            // 
+            // btnFilterByStateUnselect
+            // 
+            this.btnFilterByStateUnselect.Location = new System.Drawing.Point(560, 182);
+            this.btnFilterByStateUnselect.Name = "btnFilterByStateUnselect";
+            this.btnFilterByStateUnselect.Size = new System.Drawing.Size(88, 48);
+            this.btnFilterByStateUnselect.TabIndex = 32;
+            this.btnFilterByStateUnselect.Text = "Clear All";
+            // 
+            // btnFilterByStateSelect
+            // 
+            this.btnFilterByStateSelect.Location = new System.Drawing.Point(560, 118);
+            this.btnFilterByStateSelect.Name = "btnFilterByStateSelect";
+            this.btnFilterByStateSelect.Size = new System.Drawing.Size(88, 48);
+            this.btnFilterByStateSelect.TabIndex = 31;
+            this.btnFilterByStateSelect.Text = "Select All";
+            // 
+            // lstFilterByState
+            // 
+            this.lstFilterByState.CheckBoxes = true;
+            this.lstFilterByState.FullRowSelect = true;
+            this.lstFilterByState.GridLines = true;
+            this.lstFilterByState.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.Nonclickable;
+            this.lstFilterByState.HideSelection = false;
+            this.lstFilterByState.Location = new System.Drawing.Point(136, 32);
+            this.lstFilterByState.Name = "lstFilterByState";
+            this.lstFilterByState.Size = new System.Drawing.Size(400, 280);
+            this.lstFilterByState.TabIndex = 30;
+            this.lstFilterByState.UseCompatibleStateImageBehavior = false;
+            this.lstFilterByState.View = System.Windows.Forms.View.Details;
+            // 
+            // btnFilterByStateHelp
+            // 
+            this.btnFilterByStateHelp.ForeColor = System.Drawing.SystemColors.HotTrack;
+            this.btnFilterByStateHelp.Location = new System.Drawing.Point(16, 325);
+            this.btnFilterByStateHelp.Name = "btnFilterByStateHelp";
+            this.btnFilterByStateHelp.Size = new System.Drawing.Size(64, 24);
+            this.btnFilterByStateHelp.TabIndex = 23;
+            this.btnFilterByStateHelp.Text = "Help";
+            // 
+            // btnFilterByStatePrevious
+            // 
+            this.btnFilterByStatePrevious.Location = new System.Drawing.Point(424, 325);
+            this.btnFilterByStatePrevious.Name = "btnFilterByStatePrevious";
+            this.btnFilterByStatePrevious.Size = new System.Drawing.Size(72, 24);
+            this.btnFilterByStatePrevious.TabIndex = 22;
+            this.btnFilterByStatePrevious.Text = "< Previous";
+            // 
+            // btnFilterByStateNext
+            // 
+            this.btnFilterByStateNext.Location = new System.Drawing.Point(496, 325);
+            this.btnFilterByStateNext.Name = "btnFilterByStateNext";
+            this.btnFilterByStateNext.Size = new System.Drawing.Size(72, 24);
+            this.btnFilterByStateNext.TabIndex = 21;
+            this.btnFilterByStateNext.Text = "Next >";
+            // 
+            // btnFilterByStateCancel
+            // 
+            this.btnFilterByStateCancel.Location = new System.Drawing.Point(336, 325);
+            this.btnFilterByStateCancel.Name = "btnFilterByStateCancel";
+            this.btnFilterByStateCancel.Size = new System.Drawing.Size(64, 24);
+            this.btnFilterByStateCancel.TabIndex = 20;
+            this.btnFilterByStateCancel.Text = "Cancel";
+            this.btnFilterByStateCancel.Click += new System.EventHandler(this.btnCancel_Click);
+            // 
+            // grpboxFilterByCondId
+            // 
+            this.grpboxFilterByCondId.Controls.Add(this.btnFilterByPlotFinish);
+            this.grpboxFilterByCondId.Controls.Add(this.btnFilterByPlotUnselect);
+            this.grpboxFilterByCondId.Controls.Add(this.btnFilterByPlotSelect);
+            this.grpboxFilterByCondId.Controls.Add(this.lstFilterByCond);
+            this.grpboxFilterByCondId.Controls.Add(this.btnFilterByPlotHelp);
+            this.grpboxFilterByCondId.Controls.Add(this.btnFilterByPlotPrevious);
+            this.grpboxFilterByCondId.Controls.Add(this.btnFilterByPlotNext);
+            this.grpboxFilterByCondId.Controls.Add(this.btnFilterByPlotCancel);
+            this.grpboxFilterByCondId.ImeMode = System.Windows.Forms.ImeMode.Off;
+            this.grpboxFilterByCondId.Location = new System.Drawing.Point(16, 781);
+            this.grpboxFilterByCondId.Name = "grpboxFilterByCondId";
+            this.grpboxFilterByCondId.Size = new System.Drawing.Size(672, 360);
+            this.grpboxFilterByCondId.TabIndex = 34;
+            this.grpboxFilterByCondId.TabStop = false;
+            this.grpboxFilterByCondId.Text = "Filter By Cond";
+            // 
+            // btnFilterByPlotFinish
+            // 
+            this.btnFilterByPlotFinish.Location = new System.Drawing.Point(584, 325);
+            this.btnFilterByPlotFinish.Name = "btnFilterByPlotFinish";
+            this.btnFilterByPlotFinish.Size = new System.Drawing.Size(72, 24);
+            this.btnFilterByPlotFinish.TabIndex = 33;
+            this.btnFilterByPlotFinish.Text = "Delete";
+            this.btnFilterByPlotFinish.Click += new System.EventHandler(this.btnFilterFinish_Click);
+            // 
+            // btnFilterByPlotUnselect
+            // 
+            this.btnFilterByPlotUnselect.Location = new System.Drawing.Point(560, 180);
+            this.btnFilterByPlotUnselect.Name = "btnFilterByPlotUnselect";
+            this.btnFilterByPlotUnselect.Size = new System.Drawing.Size(88, 48);
+            this.btnFilterByPlotUnselect.TabIndex = 32;
+            this.btnFilterByPlotUnselect.Text = "Clear All";
+            // 
+            // btnFilterByPlotSelect
+            // 
+            this.btnFilterByPlotSelect.Location = new System.Drawing.Point(560, 116);
+            this.btnFilterByPlotSelect.Name = "btnFilterByPlotSelect";
+            this.btnFilterByPlotSelect.Size = new System.Drawing.Size(88, 48);
+            this.btnFilterByPlotSelect.TabIndex = 31;
+            this.btnFilterByPlotSelect.Text = "Select All";
+            // 
+            // lstFilterByCond
+            // 
+            this.lstFilterByCond.CheckBoxes = true;
+            this.lstFilterByCond.FullRowSelect = true;
+            this.lstFilterByCond.GridLines = true;
+            this.lstFilterByCond.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.Nonclickable;
+            this.lstFilterByCond.HideSelection = false;
+            this.lstFilterByCond.Location = new System.Drawing.Point(136, 32);
+            this.lstFilterByCond.MultiSelect = false;
+            this.lstFilterByCond.Name = "lstFilterByCond";
+            this.lstFilterByCond.Size = new System.Drawing.Size(400, 280);
+            this.lstFilterByCond.TabIndex = 30;
+            this.lstFilterByCond.UseCompatibleStateImageBehavior = false;
+            this.lstFilterByCond.View = System.Windows.Forms.View.Details;
+            // 
+            // btnFilterByPlotHelp
+            // 
+            this.btnFilterByPlotHelp.ForeColor = System.Drawing.SystemColors.HotTrack;
+            this.btnFilterByPlotHelp.Location = new System.Drawing.Point(16, 325);
+            this.btnFilterByPlotHelp.Name = "btnFilterByPlotHelp";
+            this.btnFilterByPlotHelp.Size = new System.Drawing.Size(64, 24);
+            this.btnFilterByPlotHelp.TabIndex = 23;
+            this.btnFilterByPlotHelp.Text = "Help";
+            // 
+            // btnFilterByPlotPrevious
+            // 
+            this.btnFilterByPlotPrevious.Location = new System.Drawing.Point(424, 325);
+            this.btnFilterByPlotPrevious.Name = "btnFilterByPlotPrevious";
+            this.btnFilterByPlotPrevious.Size = new System.Drawing.Size(72, 24);
+            this.btnFilterByPlotPrevious.TabIndex = 22;
+            this.btnFilterByPlotPrevious.Text = "< Previous";
+            // 
+            // btnFilterByPlotNext
+            // 
+            this.btnFilterByPlotNext.Enabled = false;
+            this.btnFilterByPlotNext.Location = new System.Drawing.Point(496, 325);
+            this.btnFilterByPlotNext.Name = "btnFilterByPlotNext";
+            this.btnFilterByPlotNext.Size = new System.Drawing.Size(72, 24);
+            this.btnFilterByPlotNext.TabIndex = 21;
+            this.btnFilterByPlotNext.Text = "Next >";
+            // 
+            // btnFilterByPlotCancel
+            // 
+            this.btnFilterByPlotCancel.Location = new System.Drawing.Point(336, 325);
+            this.btnFilterByPlotCancel.Name = "btnFilterByPlotCancel";
+            this.btnFilterByPlotCancel.Size = new System.Drawing.Size(64, 24);
+            this.btnFilterByPlotCancel.TabIndex = 20;
+            this.btnFilterByPlotCancel.Text = "Cancel";
+            this.btnFilterByPlotCancel.Click += new System.EventHandler(this.btnCancel_Click);
+            // 
+            // lblTitle
+            // 
+            this.lblTitle.Dock = System.Windows.Forms.DockStyle.Top;
+            this.lblTitle.Font = new System.Drawing.Font("Microsoft Sans Serif", 14F, ((System.Drawing.FontStyle)((System.Drawing.FontStyle.Bold | System.Drawing.FontStyle.Italic))), System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lblTitle.ForeColor = System.Drawing.Color.Green;
+            this.lblTitle.Location = new System.Drawing.Point(3, 16);
+            this.lblTitle.Name = "lblTitle";
+            this.lblTitle.Size = new System.Drawing.Size(698, 24);
+            this.lblTitle.TabIndex = 32;
+            this.lblTitle.Text = "Delete Conditions";
+            // 
+            // grpboxFilter
+            // 
+            this.grpboxFilter.Controls.Add(this.btnFilterFinish);
+            this.grpboxFilter.Controls.Add(this.btnFilterHelp);
+            this.grpboxFilter.Controls.Add(this.btnFilterPrevious);
+            this.grpboxFilter.Controls.Add(this.btnFilterNext);
+            this.grpboxFilter.Controls.Add(this.btnFilterCancel);
+            this.grpboxFilter.Controls.Add(this.grpboxFilterOptions);
+            this.grpboxFilter.Location = new System.Drawing.Point(16, 46);
+            this.grpboxFilter.Name = "grpboxFilter";
+            this.grpboxFilter.Size = new System.Drawing.Size(672, 361);
+            this.grpboxFilter.TabIndex = 31;
+            this.grpboxFilter.TabStop = false;
+            this.grpboxFilter.Text = "Filter Options";
+            // 
+            // btnFilterFinish
+            // 
+            this.btnFilterFinish.Enabled = false;
+            this.btnFilterFinish.Location = new System.Drawing.Point(584, 326);
+            this.btnFilterFinish.Name = "btnFilterFinish";
+            this.btnFilterFinish.Size = new System.Drawing.Size(72, 24);
+            this.btnFilterFinish.TabIndex = 5;
+            this.btnFilterFinish.Text = "Delete";
+            this.btnFilterFinish.Click += new System.EventHandler(this.btnFilterFinish_Click);
+            // 
+            // btnFilterHelp
+            // 
+            this.btnFilterHelp.ForeColor = System.Drawing.SystemColors.HotTrack;
+            this.btnFilterHelp.Location = new System.Drawing.Point(16, 326);
+            this.btnFilterHelp.Name = "btnFilterHelp";
+            this.btnFilterHelp.Size = new System.Drawing.Size(64, 24);
+            this.btnFilterHelp.TabIndex = 2;
+            this.btnFilterHelp.Text = "Help";
+            // 
+            // btnFilterPrevious
+            // 
+            this.btnFilterPrevious.Location = new System.Drawing.Point(424, 326);
+            this.btnFilterPrevious.Name = "btnFilterPrevious";
+            this.btnFilterPrevious.Size = new System.Drawing.Size(72, 24);
+            this.btnFilterPrevious.TabIndex = 4;
+            this.btnFilterPrevious.Text = "< Previous";
+            // 
+            // btnFilterNext
+            // 
+            this.btnFilterNext.Enabled = false;
+            this.btnFilterNext.Location = new System.Drawing.Point(496, 326);
+            this.btnFilterNext.Name = "btnFilterNext";
+            this.btnFilterNext.Size = new System.Drawing.Size(72, 24);
+            this.btnFilterNext.TabIndex = 5;
+            this.btnFilterNext.Text = "Next >";
+            // 
+            // btnFilterCancel
+            // 
+            this.btnFilterCancel.Location = new System.Drawing.Point(336, 326);
+            this.btnFilterCancel.Name = "btnFilterCancel";
+            this.btnFilterCancel.Size = new System.Drawing.Size(64, 24);
+            this.btnFilterCancel.TabIndex = 3;
+            this.btnFilterCancel.Text = "Cancel";
+            this.btnFilterCancel.Click += new System.EventHandler(this.btnCancel_Click);
+            // 
+            // grpboxFilterOptions
+            // 
+            this.grpboxFilterOptions.Controls.Add(this.btnFilterByFileBrowse);
+            this.grpboxFilterOptions.Controls.Add(this.txtFilterByFile);
+            this.grpboxFilterOptions.Controls.Add(this.rdoFilterByFile);
+            this.grpboxFilterOptions.Controls.Add(this.rdoFilterByMenu);
+            this.grpboxFilterOptions.Controls.Add(this.rdoDeleteAllConds);
+            this.grpboxFilterOptions.Location = new System.Drawing.Point(85, 59);
+            this.grpboxFilterOptions.Name = "grpboxFilterOptions";
+            this.grpboxFilterOptions.Size = new System.Drawing.Size(519, 249);
+            this.grpboxFilterOptions.TabIndex = 1;
+            this.grpboxFilterOptions.TabStop = false;
+            // 
+            // btnFilterByFileBrowse
+            // 
+            this.btnFilterByFileBrowse.Enabled = false;
+            this.btnFilterByFileBrowse.Image = ((System.Drawing.Image)(resources.GetObject("btnFilterByFileBrowse.Image")));
+            this.btnFilterByFileBrowse.Location = new System.Drawing.Point(408, 127);
+            this.btnFilterByFileBrowse.Name = "btnFilterByFileBrowse";
+            this.btnFilterByFileBrowse.Size = new System.Drawing.Size(32, 32);
+            this.btnFilterByFileBrowse.TabIndex = 4;
+            this.btnFilterByFileBrowse.Click += new System.EventHandler(this.btnFilterByFileBrowse_click);
+            // 
+            // txtFilterByFile
+            // 
+            this.txtFilterByFile.Enabled = false;
+            this.txtFilterByFile.Location = new System.Drawing.Point(64, 132);
+            this.txtFilterByFile.Name = "txtFilterByFile";
+            this.txtFilterByFile.Size = new System.Drawing.Size(328, 20);
+            this.txtFilterByFile.TabIndex = 3;
+            this.txtFilterByFile.TextChanged += new System.EventHandler(this.txtFilterByFile_TextChanged);
+            // 
+            // rdoFilterByFile
+            // 
+            this.rdoFilterByFile.Checked = true;
+            this.rdoFilterByFile.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.rdoFilterByFile.Location = new System.Drawing.Point(40, 92);
+            this.rdoFilterByFile.Name = "rdoFilterByFile";
+            this.rdoFilterByFile.Size = new System.Drawing.Size(400, 32);
+            this.rdoFilterByFile.TabIndex = 2;
+            this.rdoFilterByFile.TabStop = true;
+            this.rdoFilterByFile.Text = "Delete Conditions Using Text File";
+            this.rdoFilterByFile.Click += new System.EventHandler(this.rdoFilterByFile_Click);
+            // 
+            // rdoFilterByMenu
+            // 
+            this.rdoFilterByMenu.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.rdoFilterByMenu.Location = new System.Drawing.Point(40, 60);
+            this.rdoFilterByMenu.Name = "rdoFilterByMenu";
+            this.rdoFilterByMenu.Size = new System.Drawing.Size(400, 32);
+            this.rdoFilterByMenu.TabIndex = 1;
+            this.rdoFilterByMenu.Text = "Delete Conditions By Menu Selection";
+            this.rdoFilterByMenu.Click += new System.EventHandler(this.rdoFilterByMenu_Click);
+            // 
+            // rdoDeleteAllConds
+            // 
+            this.rdoDeleteAllConds.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.rdoDeleteAllConds.Location = new System.Drawing.Point(40, 28);
+            this.rdoDeleteAllConds.Name = "rdoDeleteAllConds";
+            this.rdoDeleteAllConds.Size = new System.Drawing.Size(400, 32);
+            this.rdoDeleteAllConds.TabIndex = 0;
+            this.rdoDeleteAllConds.Text = "Delete All Conditions";
+            this.rdoDeleteAllConds.Click += new System.EventHandler(this.rdoDeleteAllConds_Click);
+            // 
+            // uc_delete_conditions
+            // 
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Inherit;
+            this.Controls.Add(this.groupBox1);
+            this.Name = "uc_delete_conditions";
+            this.Size = new System.Drawing.Size(704, 1168);
+            this.groupBox1.ResumeLayout(false);
+            this.grpboxFilterByState.ResumeLayout(false);
+            this.grpboxFilterByCondId.ResumeLayout(false);
+            this.grpboxFilter.ResumeLayout(false);
+            this.grpboxFilterOptions.ResumeLayout(false);
+            this.grpboxFilterOptions.PerformLayout();
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.GroupBox groupBox1;
+        private System.Windows.Forms.GroupBox grpboxFilter;
+        private System.Windows.Forms.Button btnFilterFinish;
+        private System.Windows.Forms.Button btnFilterHelp;
+        private System.Windows.Forms.Button btnFilterPrevious;
+        private System.Windows.Forms.Button btnFilterNext;
+        private System.Windows.Forms.Button btnFilterCancel;
+        private System.Windows.Forms.GroupBox grpboxFilterOptions;
+        private System.Windows.Forms.Button btnFilterByFileBrowse;
+        private System.Windows.Forms.TextBox txtFilterByFile;
+        private System.Windows.Forms.RadioButton rdoFilterByFile;
+        private System.Windows.Forms.RadioButton rdoFilterByMenu;
+        private System.Windows.Forms.RadioButton rdoDeleteAllConds;
+        public System.Windows.Forms.Label lblTitle;
+        private System.Windows.Forms.GroupBox grpboxFilterByState;
+        private System.Windows.Forms.Button btnFilterByStateFinish;
+        private System.Windows.Forms.Button btnFilterByStateUnselect;
+        private System.Windows.Forms.Button btnFilterByStateSelect;
+        private System.Windows.Forms.ListView lstFilterByState;
+        private System.Windows.Forms.Button btnFilterByStateHelp;
+        private System.Windows.Forms.Button btnFilterByStatePrevious;
+        private System.Windows.Forms.Button btnFilterByStateNext;
+        private System.Windows.Forms.Button btnFilterByStateCancel;
+        private System.Windows.Forms.GroupBox grpboxFilterByCondId;
+        private System.Windows.Forms.Button btnFilterByPlotFinish;
+        private System.Windows.Forms.Button btnFilterByPlotUnselect;
+        private System.Windows.Forms.Button btnFilterByPlotSelect;
+        private System.Windows.Forms.ListView lstFilterByCond;
+        private System.Windows.Forms.Button btnFilterByPlotHelp;
+        private System.Windows.Forms.Button btnFilterByPlotPrevious;
+        private System.Windows.Forms.Button btnFilterByPlotNext;
+        private System.Windows.Forms.Button btnFilterByPlotCancel;
+    }
+}

--- a/src/uc_delete_conditions.Designer.cs
+++ b/src/uc_delete_conditions.Designer.cs
@@ -56,12 +56,12 @@
             this.btnFilterNext = new System.Windows.Forms.Button();
             this.btnFilterCancel = new System.Windows.Forms.Button();
             this.grpboxFilterOptions = new System.Windows.Forms.GroupBox();
+            this.label1 = new System.Windows.Forms.Label();
             this.btnFilterByFileBrowse = new System.Windows.Forms.Button();
             this.txtFilterByFile = new System.Windows.Forms.TextBox();
             this.rdoFilterByFile = new System.Windows.Forms.RadioButton();
-            this.rdoFilterByMenu = new System.Windows.Forms.RadioButton();
             this.rdoDeleteAllConds = new System.Windows.Forms.RadioButton();
-            this.label1 = new System.Windows.Forms.Label();
+            this.rdoFilterByMenu = new System.Windows.Forms.RadioButton();
             this.groupBox1.SuspendLayout();
             this.grpboxFilterByState.SuspendLayout();
             this.grpboxFilterByCondId.SuspendLayout();
@@ -309,9 +309,11 @@
             this.btnFilterHelp.Size = new System.Drawing.Size(64, 24);
             this.btnFilterHelp.TabIndex = 2;
             this.btnFilterHelp.Text = "Help";
+            this.btnFilterHelp.Visible = false;
             // 
             // btnFilterPrevious
             // 
+            this.btnFilterPrevious.Enabled = false;
             this.btnFilterPrevious.Location = new System.Drawing.Point(424, 326);
             this.btnFilterPrevious.Name = "btnFilterPrevious";
             this.btnFilterPrevious.Size = new System.Drawing.Size(72, 24);
@@ -350,11 +352,22 @@
             this.grpboxFilterOptions.TabIndex = 1;
             this.grpboxFilterOptions.TabStop = false;
             // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label1.Location = new System.Drawing.Point(6, 16);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(519, 20);
+            this.label1.TabIndex = 6;
+            this.label1.Text = "Warning: Deleting conditions is irreversible after clicking Delete.";
+            this.label1.Click += new System.EventHandler(this.label1_Click);
+            // 
             // btnFilterByFileBrowse
             // 
             this.btnFilterByFileBrowse.Enabled = false;
             this.btnFilterByFileBrowse.Image = ((System.Drawing.Image)(resources.GetObject("btnFilterByFileBrowse.Image")));
-            this.btnFilterByFileBrowse.Location = new System.Drawing.Point(408, 127);
+            this.btnFilterByFileBrowse.Location = new System.Drawing.Point(409, 120);
             this.btnFilterByFileBrowse.Name = "btnFilterByFileBrowse";
             this.btnFilterByFileBrowse.Size = new System.Drawing.Size(32, 32);
             this.btnFilterByFileBrowse.TabIndex = 4;
@@ -363,7 +376,7 @@
             // txtFilterByFile
             // 
             this.txtFilterByFile.Enabled = false;
-            this.txtFilterByFile.Location = new System.Drawing.Point(64, 132);
+            this.txtFilterByFile.Location = new System.Drawing.Point(75, 127);
             this.txtFilterByFile.Name = "txtFilterByFile";
             this.txtFilterByFile.Size = new System.Drawing.Size(328, 20);
             this.txtFilterByFile.TabIndex = 3;
@@ -373,43 +386,36 @@
             // 
             this.rdoFilterByFile.Checked = true;
             this.rdoFilterByFile.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.rdoFilterByFile.Location = new System.Drawing.Point(40, 92);
+            this.rdoFilterByFile.Location = new System.Drawing.Point(51, 91);
             this.rdoFilterByFile.Name = "rdoFilterByFile";
-            this.rdoFilterByFile.Size = new System.Drawing.Size(400, 32);
+            this.rdoFilterByFile.Size = new System.Drawing.Size(432, 32);
             this.rdoFilterByFile.TabIndex = 2;
             this.rdoFilterByFile.TabStop = true;
-            this.rdoFilterByFile.Text = "Delete Conditions Using Text File";
+            this.rdoFilterByFile.Text = "Delete Conditions with Text File of Cond.CN values";
+            this.rdoFilterByFile.CheckedChanged += new System.EventHandler(this.rdoFilterByFile_CheckedChanged);
             this.rdoFilterByFile.Click += new System.EventHandler(this.rdoFilterByFile_Click);
-            // 
-            // rdoFilterByMenu
-            // 
-            this.rdoFilterByMenu.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.rdoFilterByMenu.Location = new System.Drawing.Point(40, 60);
-            this.rdoFilterByMenu.Name = "rdoFilterByMenu";
-            this.rdoFilterByMenu.Size = new System.Drawing.Size(400, 32);
-            this.rdoFilterByMenu.TabIndex = 1;
-            this.rdoFilterByMenu.Text = "Delete Conditions By Menu Selection";
-            this.rdoFilterByMenu.Click += new System.EventHandler(this.rdoFilterByMenu_Click);
             // 
             // rdoDeleteAllConds
             // 
             this.rdoDeleteAllConds.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.rdoDeleteAllConds.Location = new System.Drawing.Point(40, 28);
+            this.rdoDeleteAllConds.Location = new System.Drawing.Point(51, 157);
             this.rdoDeleteAllConds.Name = "rdoDeleteAllConds";
             this.rdoDeleteAllConds.Size = new System.Drawing.Size(400, 32);
             this.rdoDeleteAllConds.TabIndex = 0;
             this.rdoDeleteAllConds.Text = "Delete All Conditions";
+            this.rdoDeleteAllConds.Visible = false;
             this.rdoDeleteAllConds.Click += new System.EventHandler(this.rdoDeleteAllConds_Click);
             // 
-            // label1
+            // rdoFilterByMenu
             // 
-            this.label1.AutoSize = true;
-            this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label1.Location = new System.Drawing.Point(60, 190);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(354, 20);
-            this.label1.TabIndex = 6;
-            this.label1.Text = "Warning: Deleting conditions is irreversible.";
+            this.rdoFilterByMenu.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.rdoFilterByMenu.Location = new System.Drawing.Point(51, 182);
+            this.rdoFilterByMenu.Name = "rdoFilterByMenu";
+            this.rdoFilterByMenu.Size = new System.Drawing.Size(400, 32);
+            this.rdoFilterByMenu.TabIndex = 1;
+            this.rdoFilterByMenu.Text = "Delete Conditions By Menu Selection";
+            this.rdoFilterByMenu.Visible = false;
+            this.rdoFilterByMenu.Click += new System.EventHandler(this.rdoFilterByMenu_Click);
             // 
             // uc_delete_conditions
             // 
@@ -440,8 +446,6 @@
         private System.Windows.Forms.Button btnFilterByFileBrowse;
         private System.Windows.Forms.TextBox txtFilterByFile;
         private System.Windows.Forms.RadioButton rdoFilterByFile;
-        private System.Windows.Forms.RadioButton rdoFilterByMenu;
-        private System.Windows.Forms.RadioButton rdoDeleteAllConds;
         public System.Windows.Forms.Label lblTitle;
         private System.Windows.Forms.GroupBox grpboxFilterByState;
         private System.Windows.Forms.Button btnFilterByStateFinish;
@@ -462,5 +466,7 @@
         private System.Windows.Forms.Button btnFilterByPlotNext;
         private System.Windows.Forms.Button btnFilterByPlotCancel;
         private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.RadioButton rdoFilterByMenu;
+        private System.Windows.Forms.RadioButton rdoDeleteAllConds;
     }
 }

--- a/src/uc_delete_conditions.Designer.cs
+++ b/src/uc_delete_conditions.Designer.cs
@@ -61,6 +61,7 @@
             this.rdoFilterByFile = new System.Windows.Forms.RadioButton();
             this.rdoFilterByMenu = new System.Windows.Forms.RadioButton();
             this.rdoDeleteAllConds = new System.Windows.Forms.RadioButton();
+            this.label1 = new System.Windows.Forms.Label();
             this.groupBox1.SuspendLayout();
             this.grpboxFilterByState.SuspendLayout();
             this.grpboxFilterByCondId.SuspendLayout();
@@ -337,6 +338,7 @@
             // 
             // grpboxFilterOptions
             // 
+            this.grpboxFilterOptions.Controls.Add(this.label1);
             this.grpboxFilterOptions.Controls.Add(this.btnFilterByFileBrowse);
             this.grpboxFilterOptions.Controls.Add(this.txtFilterByFile);
             this.grpboxFilterOptions.Controls.Add(this.rdoFilterByFile);
@@ -399,6 +401,16 @@
             this.rdoDeleteAllConds.Text = "Delete All Conditions";
             this.rdoDeleteAllConds.Click += new System.EventHandler(this.rdoDeleteAllConds_Click);
             // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label1.Location = new System.Drawing.Point(60, 190);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(354, 20);
+            this.label1.TabIndex = 6;
+            this.label1.Text = "Warning: Deleting conditions is irreversible.";
+            // 
             // uc_delete_conditions
             // 
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Inherit;
@@ -449,5 +461,6 @@
         private System.Windows.Forms.Button btnFilterByPlotPrevious;
         private System.Windows.Forms.Button btnFilterByPlotNext;
         private System.Windows.Forms.Button btnFilterByPlotCancel;
+        private System.Windows.Forms.Label label1;
     }
 }

--- a/src/uc_delete_conditions.Designer.cs
+++ b/src/uc_delete_conditions.Designer.cs
@@ -361,7 +361,6 @@
             this.label1.Size = new System.Drawing.Size(519, 20);
             this.label1.TabIndex = 6;
             this.label1.Text = "Warning: Deleting conditions is irreversible after clicking Delete.";
-            this.label1.Click += new System.EventHandler(this.label1_Click);
             // 
             // btnFilterByFileBrowse
             // 
@@ -392,7 +391,6 @@
             this.rdoFilterByFile.TabIndex = 2;
             this.rdoFilterByFile.TabStop = true;
             this.rdoFilterByFile.Text = "Delete Conditions with Text File of Cond.CN values";
-            this.rdoFilterByFile.CheckedChanged += new System.EventHandler(this.rdoFilterByFile_CheckedChanged);
             this.rdoFilterByFile.Click += new System.EventHandler(this.rdoFilterByFile_Click);
             // 
             // rdoDeleteAllConds

--- a/src/uc_delete_conditions.cs
+++ b/src/uc_delete_conditions.cs
@@ -284,7 +284,7 @@ namespace FIA_Biosum_Manager
 
                 //ProjectRoot\db Section
                 UpdateProgressBar2(20);
-                ConnectToDatabasesInPathAndExecuteDeletes(Directory.GetFiles(m_strProjDir + "\\db\\", "*.mdb"));
+                ConnectToDatabasesInPathAndExecuteDeletes(Directory.GetFiles(m_strProjDir + "\\db\\", "*.mdb"), strTableExceptions: new string[] {"tree_regional_biomass"});
 
                 //ProjectRoot\gis Section
                 UpdateProgressBar2(30);
@@ -513,9 +513,9 @@ namespace FIA_Biosum_Manager
                 //Only usage of cnd_cn is in FCS schema, which uses biosum_cond_id values
                 {"cnd_cn", new object[] {setBiosumCondCNs, m_strBiosumCondCNs}},
                 //plt_cn used in two tables. pop_plot_stratum_assgn uses plot.cn, fcs uses biosum_plot_id
-                {"plt_cn", new object[] {setPlotCNs, m_strPlotCNs}},
+                //{"plt_cn", new object[] {setPlotCNs, m_strPlotCNs}},
                 //used in master.tree_regional_biomass. values are tree.cn
-                {"tre_cn", new object[] {setTreeCNs, m_strTreeCNs}},
+                //{"tre_cn", new object[] {setTreeCNs, m_strTreeCNs}},
             };
         }
 

--- a/src/uc_delete_conditions.cs
+++ b/src/uc_delete_conditions.cs
@@ -53,6 +53,7 @@ namespace FIA_Biosum_Manager
         private string m_strCurrentProcess;
         private frmTherm m_frmTherm;
         private ado_data_access m_ado;
+        private dao_data_access m_dao;
         private OleDbConnection m_connTempMDBFile;
         private string m_strTempMDBFileConn;
         private string m_strTempMDBFile;
@@ -251,6 +252,8 @@ namespace FIA_Biosum_Manager
             try
             {
                 this.m_ado = new ado_data_access();
+                this.m_dao = new dao_data_access();
+
                 //progress bar 1: single process
                 this.SetThermValue(m_frmTherm.progressBar1, "Maximum", 100);
                 this.SetThermValue(m_frmTherm.progressBar1, "Minimum", 0);
@@ -344,6 +347,10 @@ namespace FIA_Biosum_Manager
                         this.m_ado.m_DataSet.Dispose();
                     }
                     this.m_ado = null;
+                }
+                if (m_dao != null)
+                {
+                    this.m_dao = null;
                 }
 
                 frmMain.g_oDelegate.SetControlPropertyValue((System.Windows.Forms.Form) ReferenceFormDialog, "Visible",
@@ -550,6 +557,7 @@ namespace FIA_Biosum_Manager
                 }
             }
             m_ado.CloseConnection(oConn);
+            m_dao.CompactMDB(strDbPathFile);
         }
 
         private void BuildAndExecuteDeleteSQLStmts(OleDbConnection oConn, string table, string column)

--- a/src/uc_delete_conditions.cs
+++ b/src/uc_delete_conditions.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Data;
+using System.Data.OleDb;
+using System.Threading;
 using System.Windows.Forms;
 
 namespace FIA_Biosum_Manager
@@ -21,19 +23,28 @@ namespace FIA_Biosum_Manager
         private string m_strPopStratumTable;
         private string m_strPopEvalTable;
         private string m_strBiosumPopStratumAdjustmentFactorsTable;
+
         private string m_strTreeMacroPlotBreakPointDiaTable;
         //TODO: more strings to hold FVSOUT table information?
 
         //TODO:for collecting biosum_cond_id values from text file
-		private string m_strBiosumCondIds="";
+        private string m_strBiosumCondIds = "";
 
         //TODO: Help files
         private env m_oEnv;
+
         private Help m_oHelp;
         private string m_xpsFile = Help.DefaultDatabaseXPSFile;
         private int m_intError;
         private string m_strStateCountyPlotSQL;
         private string m_strStateCountySQL;
+        private string m_strCurrentProcess;
+        private frmTherm m_frmTherm;
+        private ado_data_access m_ado;
+        private OleDbConnection m_connTempMDBFile;
+        private string m_strTempMDBFileConn;
+        private string m_strTempMDBFile;
+        private string m_strSQL;
 
         public uc_delete_conditions()
         {
@@ -145,7 +156,6 @@ namespace FIA_Biosum_Manager
 
         private void rdoDeleteAllConds_Click(object sender, System.EventArgs e)
         {
-
             this.btnFilterFinish.Enabled = true;
             this.btnFilterNext.Enabled = true;
             this.txtFilterByFile.Enabled = false;
@@ -154,7 +164,7 @@ namespace FIA_Biosum_Manager
 
         private void btnCancel_Click(object sender, System.EventArgs e)
         {
-            ((frmDialog)this.ParentForm).Close();
+            ((frmDialog) this.ParentForm).Close();
         }
 
         private void btnFilterFinish_Click(object sender, System.EventArgs e)
@@ -174,38 +184,448 @@ namespace FIA_Biosum_Manager
                     MessageBox.Show("You really want to delete everything here?");
 //                    throw new NotImplementedException("This should eventually delete ALL conds/plots/trees through the FVSOUT phase of BioSum.");
                     //delete pretty much everything. building a string of 1+ biosum_cond_ids is skipped (filter by file radio button not selected)
-                    DeleteCondsFromBiosumProject();
+                    DeleteCondsFromBiosumProject_Start();
                 }
                 else if (this.rdoFilterByMenu.Checked)
                 {
                     MessageBox.Show("Deleting conds based on menu selection...");
 //                    throw new NotImplementedException("Eventually deletes specific conds/plots/trees through the FVSOUT phase of BioSum.");
-                    DeleteCondsFromBiosumProject();
+                    DeleteCondsFromBiosumProject_Start();
                 }
                 else if (this.rdoFilterByFile.Checked)
                 {
                     if (System.IO.File.Exists(this.txtFilterByFile.Text.Trim()) == true)
                     {
-                        this.m_strBiosumCondIds = this.CreateDelimitedStringList(this.txtFilterByFile.Text.Trim(), ",", ",", false);
+                        this.m_strBiosumCondIds =
+                            this.CreateDelimitedStringList(this.txtFilterByFile.Text.Trim(), ",", ",", false);
                         if (this.m_intError == 0)
                         {
                             //this.LoadMDBPlotCondTreeData_Start();
-                            MessageBox.Show("This would be deleting information related to the following conditions:" + m_strBiosumCondIds);
+                            MessageBox.Show("This would be deleting information related to the following conditions:" +
+                                            m_strBiosumCondIds);
 //                            throw new NotImplementedException("This should eventually delete SPECIFIC conds/plots/trees through the FVSOUT phase of BioSum.");
-                            DeleteCondsFromBiosumProject();
+                            DeleteCondsFromBiosumProject_Start();
                         }
                     }
                     else
                     {
-                        MessageBox.Show("!!" + this.txtFilterByFile.Text.Trim() + " could not be found!!", "Delete Conditions", System.Windows.Forms.MessageBoxButtons.OK, System.Windows.Forms.MessageBoxIcon.Exclamation);
+                        MessageBox.Show("!!" + this.txtFilterByFile.Text.Trim() + " could not be found!!",
+                            "Delete Conditions", System.Windows.Forms.MessageBoxButtons.OK,
+                            System.Windows.Forms.MessageBoxIcon.Exclamation);
                     }
                 }
             }
+
+            //Close the form after deleting condititions finished
+            //((frmDialog) this.ParentForm).Close(); //causes premature disposal with multithreaded applications
         }
 
-        private void DeleteCondsFromBiosumProject()
+        //throw new NotImplementedException("Delete conds, with or without filters, using m_strBiosumCondIds built with either a text file or GUI menu. use it to collect biosum_cond_ids, plot.cn, tree.cn");
+        private void DeleteCondsFromBiosumProject_Start()
         {
-            //throw new NotImplementedException("Delete conds, with or without filters, using m_strBiosumCondIds built with either a text file or GUI menu. use it to collect biosum_cond_ids, plot.cn, tree.cn");
+            frmMain.g_oDelegate.InitializeThreadEvents();
+            frmMain.g_oDelegate.m_oEventStopThread.Reset();
+            frmMain.g_oDelegate.m_oEventThreadStopped.Reset();
+            frmMain.g_oDelegate.CurrentThreadProcessAborted = false;
+            frmMain.g_oDelegate.CurrentThreadProcessDone = false;
+            frmMain.g_oDelegate.CurrentThreadProcessStarted = false;
+            this.m_strCurrentProcess = "DeleteConditions";
+            this.StartTherm("2", "Delete Biosum Condition Data");
+            frmMain.g_oDelegate.m_oThread = new Thread(new ThreadStart(DeleteCondsFromBiosumProject_Process));
+            frmMain.g_oDelegate.m_oThread.IsBackground = true;
+            frmMain.g_oDelegate.CurrentThreadProcessIdle = false;
+            frmMain.g_oDelegate.m_oThread.Start();
+        }
+
+        private void DeleteCondsFromBiosumProject_Process()
+        {
+            frmMain.g_oDelegate.CurrentThreadProcessStarted = true;
+
+            this.m_intError = 0;
+
+            //-----------PREPARATION FOR DELETING COND RECORDS---------//
+
+            try
+            {
+                this.m_ado = new ado_data_access();
+
+                //progress bar 1: single process
+                this.SetThermValue(m_frmTherm.progressBar1, "Maximum", 100);
+                this.SetThermValue(m_frmTherm.progressBar1, "Minimum", 0);
+                this.SetThermValue(m_frmTherm.progressBar1, "Value", 0);
+                this.SetLabelValue(m_frmTherm.lblMsg, "Text", "");
+                frmMain.g_oDelegate.SetControlPropertyValue((System.Windows.Forms.Form) m_frmTherm, "Visible", true);
+
+                //progress bar 2: overall progress
+                this.SetThermValue(m_frmTherm.progressBar2, "Maximum", 100);
+                this.SetThermValue(m_frmTherm.progressBar2, "Minimum", 0);
+                this.SetThermValue(m_frmTherm.progressBar2, "Value", 0);
+                this.SetLabelValue(m_frmTherm.lblMsg2, "Text", "Overall Progress");
+                frmMain.g_oDelegate.SetControlPropertyValue((System.Windows.Forms.Form) m_frmTherm, "Visible", true);
+
+
+                //create a temporary mdb file with links to all the project tables
+                //and return the name of the file that contains the links
+                this.m_strTempMDBFile = m_oDatasource.CreateMDBAndTableDataSourceLinks();
+
+
+                //TODO: Create a table with bscid, bspid, p.cn, t.cn to query from 
+
+
+                //instatiate dao for creating links in the temp table
+                //to the fiadb plot, cond, and tree input tables
+                dao_data_access p_dao1 = new dao_data_access();
+                this.SetLabelValue(m_frmTherm.lblMsg, "Text", "NAME OF STEP"); //todo: rename step label
+
+//                //cond table
+//                strSourceTableName = "BIOSUM_COND";
+//                strDestTableLinkName = "fiadb_cond_input";
+//                if (p_dao1.m_intError == 0)
+//                    p_dao1.CreateTableLink(this.m_strTempMDBFile, strDestTableLinkName, strFIADBDbFile,
+//                        strSourceTableName, true);
+//                //tree table
+//                str2 = (string) frmMain.g_oDelegate.GetControlPropertyValue(
+//                    (System.Windows.Forms.ComboBox) cmbFiadbTreeTable, "Text", false);
+//                if (p_dao1.m_intError == 0)
+//                    p_dao1.CreateTableLink(this.m_strTempMDBFile, "fiadb_tree_input", strFIADBDbFile, str2.Trim());
+//                //tree regional biomass
+//                str2 = (string) frmMain.g_oDelegate.GetControlPropertyValue(
+//                    (System.Windows.Forms.ComboBox) cmbFiadbTreeRegionalBiomassTable, "Text", false);
+//                if (p_dao1.m_intError == 0 && str2.Trim().Length > 0 && str2.Trim() != "<Optional Table>")
+//                    p_dao1.CreateTableLink(this.m_strTempMDBFile, "fiadb_treeRegionalBiomass_input", strFIADBDbFile,
+//                        str2.Trim());
+//                //site tree
+//                str2 = (string) frmMain.g_oDelegate.GetControlPropertyValue(
+//                    (System.Windows.Forms.ComboBox) cmbFiadbSiteTreeTable, "Text", false);
+//                if (p_dao1.m_intError == 0)
+//                    p_dao1.CreateTableLink(this.m_strTempMDBFile, "fiadb_site_tree_input", strFIADBDbFile, str2.Trim());
+
+
+                m_intError = p_dao1.m_intError;
+
+                //destroy the object and release it from memory
+                p_dao1.m_DaoWorkspace.Close();
+                p_dao1 = null;
+
+
+                frmMain.g_oDelegate.SetControlPropertyValue((System.Windows.Forms.Control) this.m_frmTherm.progressBar1,
+                    "Value", 10);
+
+                System.Data.DataTable dtPlotSchema = new DataTable();
+                System.Data.DataTable dtCondSchema = new DataTable();
+                System.Data.DataTable dtTreeSchema = new DataTable();
+                System.Data.DataTable dtSiteTreeSchema = new DataTable();
+                System.Data.DataTable dtFIADBPlotSchema = new DataTable();
+                System.Data.DataTable dtFIADBCondSchema = new DataTable();
+                System.Data.DataTable dtFIADBTreeSchema = new DataTable();
+                System.Data.DataTable dtFIADBSiteTreeSchema = new DataTable();
+
+
+                //get an ado connection string for the temp mdb file
+                this.m_strTempMDBFileConn = this.m_ado.getMDBConnString(this.m_strTempMDBFile, "", "");
+
+
+                //create a new connection to the temp MDB file
+                this.m_connTempMDBFile = new System.Data.OleDb.OleDbConnection();
+
+                //open the connection to the temp mdb file 
+                this.m_ado.OpenConnection(this.m_strTempMDBFileConn, ref this.m_connTempMDBFile);
+
+
+                if (this.m_intError == 0 && !GetBooleanValue((System.Windows.Forms.Control) m_frmTherm, "AbortProcess"))
+                {
+                    SetThermValue(m_frmTherm.progressBar1, "Value", 20);
+
+                    /****************************************************************
+                     **get the table structure that results from executing the sql
+                     ****************************************************************/
+                    //get the fiabiosum table structures
+                    dtPlotSchema =
+                        this.m_ado.getTableSchema(this.m_connTempMDBFile, "select * from " + this.m_strPlotTable);
+                    dtCondSchema =
+                        this.m_ado.getTableSchema(this.m_connTempMDBFile, "select * from " + this.m_strCondTable);
+                    dtTreeSchema =
+                        this.m_ado.getTableSchema(this.m_connTempMDBFile, "select * from " + this.m_strTreeTable);
+                    dtSiteTreeSchema = this.m_ado.getTableSchema(this.m_connTempMDBFile,
+                        "select * from " + this.m_strSiteTreeTable);
+                    //get the fiadb table structures
+                    m_intError = m_ado.m_intError;
+                }
+
+                
+
+                
+                
+                
+                
+
+                
+                
+
+       
+          
+
+
+                //TODO: make this a function to call repeatedly with different m_strSQL values, connections, and progress bar values
+                if (m_intError == 0 && !GetBooleanValue((System.Windows.Forms.Control) m_frmTherm, "AbortProcess"))
+                {
+                    SetThermValue(m_frmTherm.progressBar1, "Value", 80);
+                    m_ado.m_strSQL = "SELECT 1;"; //todo: delete from table where ___ in () function
+                    this.m_ado.SqlNonQuery(this.m_connTempMDBFile, this.m_ado.m_strSQL);
+                    m_intError = m_ado.m_intError;
+                }
+
+                if (m_intError == 0 && !GetBooleanValue((System.Windows.Forms.Control) m_frmTherm, "AbortProcess"))
+                {
+                }
+                if (m_intError == 0 && !GetBooleanValue((System.Windows.Forms.Control) m_frmTherm, "AbortProcess"))
+                {
+                }
+                else
+                {
+                    MessageBox.Show("Some error occured in deleting conditions.");
+                }
+
+
+                this.m_connTempMDBFile.Close();
+                while (m_connTempMDBFile.State != System.Data.ConnectionState.Closed)
+                    System.Threading.Thread.Sleep(1000);
+                //this.m_ado.m_DataSet.Clear(); //todo: if m_DataSet is null, clear has null reference exception thrown
+                //this.m_ado.m_DataSet.Dispose();
+                this.m_ado = null;
+
+                frmMain.g_oDelegate.SetControlPropertyValue((System.Windows.Forms.Form) ReferenceFormDialog, "Visible",
+                    true);
+                frmMain.g_oDelegate.SetControlPropertyValue((System.Windows.Forms.Form) ReferenceFormDialog, "Enabled",
+                    true);
+
+
+                DeleteCondsFromBiosumProject_Finish();
+            }
+            catch (System.Threading.ThreadInterruptedException err)
+            {
+                MessageBox.Show("Threading Interruption Error " + err.Message.ToString());
+            }
+            catch (System.Threading.ThreadAbortException err)
+            {
+                if (this.m_connTempMDBFile != null)
+                {
+                    if (m_connTempMDBFile.State != System.Data.ConnectionState.Closed)
+                    {
+                        m_ado.CloseConnection(m_connTempMDBFile);
+                    }
+                    m_connTempMDBFile = null;
+                }
+                if (m_ado != null)
+                {
+                    if (m_ado.m_DataSet != null)
+                    {
+                        this.m_ado.m_DataSet.Clear();
+                        this.m_ado.m_DataSet.Dispose();
+                    }
+                    this.m_ado = null;
+                }
+//                this.CancelThreadCleanup();
+                this.ThreadCleanUp();
+                this.CleanupThread();
+            }
+            catch (Exception err)
+            {
+                MessageBox.Show("!!Error!! \n" +
+                                "Module - uc_delete_conditions:DeleteCondsFromBiosumProject_Process  \n" +
+                                "Err Msg - " + err.Message.ToString().Trim(),
+                    "FVS Biosum", System.Windows.Forms.MessageBoxButtons.OK,
+                    System.Windows.Forms.MessageBoxIcon.Exclamation);
+                this.m_intError = -1;
+            }
+            finally
+            {
+            }
+
+            if (this.m_connTempMDBFile != null)
+            {
+                if (m_connTempMDBFile.State != System.Data.ConnectionState.Closed)
+                {
+                    m_ado.CloseConnection(m_connTempMDBFile);
+                }
+                m_connTempMDBFile = null;
+            }
+            if (m_ado != null)
+            {
+                if (m_ado.m_DataSet != null)
+                {
+                    this.m_ado.m_DataSet.Clear();
+                    this.m_ado.m_DataSet.Dispose();
+                }
+                this.m_ado = null;
+            }
+            frmMain.g_oDelegate.SetControlPropertyValue((System.Windows.Forms.Form) ReferenceFormDialog, "Enabled",
+                true);
+            if (this.m_frmTherm != null)
+                frmMain.g_oDelegate.SetControlPropertyValue((System.Windows.Forms.Form) m_frmTherm, "Visible", false);
+
+
+            DeleteCondsFromBiosumProject_Finish();
+
+            CleanupThread();
+
+            frmMain.g_oDelegate.m_oEventThreadStopped.Set();
+            this.Invoke(frmMain.g_oDelegate.m_oDelegateThreadFinished);
+
+            //TODO: Experiment: Does this cause issues with disposing resources before they're done being used?
+            ((frmDialog) this.ParentForm).Close();
+        }
+
+        private void CleanupThread()
+        {
+            // ((frmDialog)this.ParentForm).m_frmMain.Visible = true;
+            frmMain.g_oDelegate.SetControlPropertyValue((System.Windows.Forms.Form) ReferenceFormDialog, "Visible",
+                true);
+            frmMain.g_oDelegate.SetControlPropertyValue((System.Windows.Forms.Form) ReferenceFormDialog, "Enabled",
+                true);
+        }
+
+        private void ThreadCleanUp()
+        {
+            try
+            {
+                // ((frmDialog)this.ParentForm).m_frmMain.Visible = true;
+                frmMain.g_oDelegate.SetControlPropertyValue((System.Windows.Forms.Form) ReferenceFormDialog, "Visible",
+                    true);
+                frmMain.g_oDelegate.SetControlPropertyValue((System.Windows.Forms.Form) ReferenceFormDialog, "Enabled",
+                    true);
+
+                if (this.m_frmTherm != null)
+                {
+                    frmMain.g_oDelegate.ExecuteControlMethod((System.Windows.Forms.Form) m_frmTherm, "Close");
+                    frmMain.g_oDelegate.ExecuteControlMethod((System.Windows.Forms.Form) m_frmTherm, "Dispose");
+
+                    this.m_frmTherm = null;
+                }
+            }
+            catch
+            {
+            }
+        }
+
+        private void DeleteCondsFromBiosumProject_Finish()
+        {
+//            this.m_strPlotIdList = "";
+
+
+            if (this.m_frmTherm != null)
+            {
+                frmMain.g_oDelegate.ExecuteControlMethod(m_frmTherm, "Close");
+                frmMain.g_oDelegate.ExecuteControlMethod(m_frmTherm, "Dispose");
+                this.m_frmTherm = null;
+            }
+            if (m_intError != 0)
+            {
+//                this.m_strLoadedPopEstUnitInputTable = "";
+//                this.m_strLoadedPopStratumInputTable = "";
+//                this.m_strLoadedPpsaInputTable = "";
+//                this.m_strLoadedFiadbInputFile = "";
+            }
+            else
+            {
+//                this.m_strLoadedPopEstUnitTxtInputFile = "";
+//                this.m_strLoadedPopEvalTxtInputFile = "";
+//                this.m_strLoadedPopStratumTxtInputFile = "";
+//                this.m_strLoadedPpsaTxtInputFile = "";
+            }
+            this.m_strCurrentProcess = "";
+            frmMain.g_oDelegate.SetControlPropertyValue(this, "Enabled", true);
+            //((frmDialog) this.ParentForm).MinimizeMainForm = false;
+        }
+
+
+        private void StartTherm(string p_strNumberOfTherms, string p_strTitle)
+        {
+            this.m_frmTherm = new frmTherm((frmDialog) this.ParentForm, p_strTitle);
+
+            this.m_frmTherm.Text = p_strTitle;
+            this.m_frmTherm.lblMsg.Text = "";
+            this.m_frmTherm.lblMsg2.Text = "";
+            this.m_frmTherm.Visible = false;
+            this.m_frmTherm.btnCancel.Visible = true;
+            this.m_frmTherm.lblMsg.Visible = true;
+            this.m_frmTherm.progressBar1.Minimum = 0;
+            this.m_frmTherm.progressBar1.Visible = true;
+            this.m_frmTherm.progressBar1.Maximum = 10;
+
+            if (p_strNumberOfTherms == "2")
+            {
+                this.m_frmTherm.progressBar2.Size = this.m_frmTherm.progressBar1.Size;
+                this.m_frmTherm.progressBar2.Left = this.m_frmTherm.progressBar1.Left;
+                this.m_frmTherm.progressBar2.Top =
+                    Convert.ToInt32(this.m_frmTherm.progressBar1.Top + (this.m_frmTherm.progressBar1.Height * 3));
+                this.m_frmTherm.lblMsg2.Top =
+                    this.m_frmTherm.progressBar2.Top + this.m_frmTherm.progressBar2.Height + 5;
+                this.m_frmTherm.Height = this.m_frmTherm.lblMsg2.Top + this.m_frmTherm.lblMsg2.Height +
+                                         this.m_frmTherm.btnCancel.Height + 50;
+                this.m_frmTherm.btnCancel.Top =
+                    this.m_frmTherm.ClientSize.Height - this.m_frmTherm.btnCancel.Height - 5;
+                this.m_frmTherm.lblMsg2.Show();
+                this.m_frmTherm.progressBar2.Visible = true;
+            }
+            this.m_frmTherm.AbortProcess = false;
+            this.m_frmTherm.Refresh();
+            this.m_frmTherm.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            //((frmDialog)this.ParentForm).Enabled=false;
+            this.m_frmTherm.Visible = true;
+        }
+
+        public void StopThread()
+        {
+            string strMsg = "";
+
+            frmMain.g_oDelegate.AbortProcessing("FIA Biosum", "Do you wish to cancel adding plot data?");
+
+            if (frmMain.g_oDelegate.CurrentThreadProcessAborted)
+            {
+                frmMain.g_oDelegate.SetControlPropertyValue((System.Windows.Forms.Form) m_frmTherm, "AbortProcess",
+                    true);
+//                this.CancelThreadCleanup();
+//                this.ThreadCleanUp();
+                throw new NotImplementedException();
+            }
+        }
+
+        private bool Checked(System.Windows.Forms.RadioButton p_rdoButton)
+        {
+            return (bool) frmMain.g_oDelegate.GetControlPropertyValue((System.Windows.Forms.RadioButton) p_rdoButton,
+                "Checked", false);
+        }
+
+        private bool Checked(System.Windows.Forms.CheckBox p_chkBox)
+        {
+            return (bool) frmMain.g_oDelegate.GetControlPropertyValue((System.Windows.Forms.CheckBox) p_chkBox,
+                "Checked", false);
+        }
+
+        private void SetThermValue(System.Windows.Forms.ProgressBar p_oPb, string p_strPropertyName, int p_intValue)
+        {
+            frmMain.g_oDelegate.SetControlPropertyValue((System.Windows.Forms.Control) p_oPb, p_strPropertyName,
+                (int) p_intValue);
+        }
+
+        private int GetThermValue(System.Windows.Forms.ProgressBar p_oPb, string p_strPropertyName)
+        {
+            return (int) frmMain.g_oDelegate.GetControlPropertyValue((System.Windows.Forms.Control) p_oPb,
+                p_strPropertyName, false);
+        }
+
+        private bool GetBooleanValue(System.Windows.Forms.Control p_oControl, string p_strPropertyName)
+        {
+            return (bool) frmMain.g_oDelegate.GetControlPropertyValue((System.Windows.Forms.Control) p_oControl,
+                p_strPropertyName, false);
+        }
+
+
+        private void SetLabelValue(System.Windows.Forms.Label p_oLabel, string p_strPropertyName, string p_strValue)
+        {
+            frmMain.g_oDelegate.SetControlPropertyValue((System.Windows.Forms.Label) p_oLabel, p_strPropertyName,
+                p_strValue);
         }
 
         public frmDialog ReferenceFormDialog { set; get; }
@@ -226,74 +646,74 @@ namespace FIA_Biosum_Manager
         }
 
         /// <summary>
-		/// create a delimited string list from a text file
-		/// that has a single column of data with multiple rows
-		/// </summary>
-		/// <param name="p_strTxtFile">text file containing the column of data</param>
-		/// <param name="p_strTxtFileDelimiter">specified character between list items</param>
-		/// <param name="p_strListDelimiter">specified character between list items</param>
-		/// <param name="p_bNumericDataType">specifies if the column data to retrieve in the text file is numeric</param>
-		/// <returns></returns>
-		private string CreateDelimitedStringList(string p_strTxtFile,string p_strTxtFileDelimiter, string p_strListDelimiter,bool p_bNumericDataType)
-		{
-			//The DataSet to Return
-			//DataSet result = new DataSet();
-			this.m_intError=0;
-			string strList="";
-			string str="";
-			try
-			{
-				//Open the file in a stream reader.
-				System.IO.StreamReader s = new System.IO.StreamReader(p_strTxtFile);
-				//Read the rest of the data in the file.        
-				string AllData = s.ReadToEnd();
-    
-				//Split off each row at the Carriage Return/Line Feed
-				//Default line ending in most <A class=iAs style="FONT-WEIGHT: normal; FONT-SIZE: 100%; PADDING-BOTTOM: 1px; COLOR: darkgreen; BORDER-BOTTOM: darkgreen 0.07em solid; BACKGROUND-COLOR: transparent; TEXT-DECORATION: underline" href="#" target=_blank itxtdid="2592535">windows</A> exports.  
-				string[] rows = AllData.Split("\r\n".ToCharArray());
- 
-				//Now add each row to the DataSet        
-				foreach(string r in rows)
-				{
-					//Split the row at the delimiter.
-					string[] items = r.Split(p_strTxtFileDelimiter.ToCharArray());
-					str = items[0].Trim();  //plot_cn in first column
-					str = str.Replace("\"",""); //remove any quotations
-					if (str.Trim().Length > 0)
-					{
-						if (strList.Trim().Length == 0)
-						{
-							if (p_bNumericDataType == true)
-							{
-								strList = str.Trim();
-							}
-							else
-							{
-								strList = "'" + str.Trim() + "'";
-							}
-						}
-						else
-						{
-							if (p_bNumericDataType == true)
-							{
-								strList = strList + p_strListDelimiter.Trim() + str.Trim();
-							}
-							else
-							{
-								strList = strList + p_strListDelimiter.Trim() + "'" + str.Trim() + "'";
-							}
+        /// create a delimited string list from a text file
+        /// that has a single column of data with multiple rows
+        /// </summary>
+        /// <param name="p_strTxtFile">text file containing the column of data</param>
+        /// <param name="p_strTxtFileDelimiter">specified character between list items</param>
+        /// <param name="p_strListDelimiter">specified character between list items</param>
+        /// <param name="p_bNumericDataType">specifies if the column data to retrieve in the text file is numeric</param>
+        /// <returns></returns>
+        private string CreateDelimitedStringList(string p_strTxtFile, string p_strTxtFileDelimiter,
+            string p_strListDelimiter, bool p_bNumericDataType)
+        {
+            //The DataSet to Return
+            //DataSet result = new DataSet();
+            this.m_intError = 0;
+            string strList = "";
+            string str = "";
+            try
+            {
+                //Open the file in a stream reader.
+                System.IO.StreamReader s = new System.IO.StreamReader(p_strTxtFile);
+                //Read the rest of the data in the file.        
+                string AllData = s.ReadToEnd();
 
-						}
-					}
-				}
-			}
-			catch (Exception caught)
-			{
-				this.m_intError=-1;
-				MessageBox.Show("!!Error: CreateDelimitedStringList() Routine Error Msg:" + caught.Message);
-			}
-			return strList;
-		}
+                //Split off each row at the Carriage Return/Line Feed
+                //Default line ending in most <A class=iAs style="FONT-WEIGHT: normal; FONT-SIZE: 100%; PADDING-BOTTOM: 1px; COLOR: darkgreen; BORDER-BOTTOM: darkgreen 0.07em solid; BACKGROUND-COLOR: transparent; TEXT-DECORATION: underline" href="#" target=_blank itxtdid="2592535">windows</A> exports.  
+                string[] rows = AllData.Split("\r\n".ToCharArray());
+
+                //Now add each row to the DataSet        
+                foreach (string r in rows)
+                {
+                    //Split the row at the delimiter.
+                    string[] items = r.Split(p_strTxtFileDelimiter.ToCharArray());
+                    str = items[0].Trim(); //plot_cn in first column
+                    str = str.Replace("\"", ""); //remove any quotations
+                    if (str.Trim().Length > 0)
+                    {
+                        if (strList.Trim().Length == 0)
+                        {
+                            if (p_bNumericDataType == true)
+                            {
+                                strList = str.Trim();
+                            }
+                            else
+                            {
+                                strList = "'" + str.Trim() + "'";
+                            }
+                        }
+                        else
+                        {
+                            if (p_bNumericDataType == true)
+                            {
+                                strList = strList + p_strListDelimiter.Trim() + str.Trim();
+                            }
+                            else
+                            {
+                                strList = strList + p_strListDelimiter.Trim() + "'" + str.Trim() + "'";
+                            }
+                        }
+                    }
+                }
+            }
+            catch (Exception caught)
+            {
+                this.m_intError = -1;
+                MessageBox.Show("!!Error: CreateDelimitedStringList() Routine Error Msg:" + caught.Message);
+            }
+            return strList;
+        }
 
         private void txtFilterByFile_TextChanged(object sender, EventArgs e)
         {

--- a/src/uc_delete_conditions.cs
+++ b/src/uc_delete_conditions.cs
@@ -114,6 +114,9 @@ namespace FIA_Biosum_Manager
             m_dtPlot.Columns.Add("countycd", typeof(string));
             m_dtPlot.Columns.Add("plot", typeof(string));
 
+            rdoFilterByMenu.Enabled = false;
+            rdoDeleteAllConds.Enabled = false;
+
             m_oEnv = new env();
         }
 
@@ -184,23 +187,21 @@ namespace FIA_Biosum_Manager
             this.m_strStateCountySQL = "";
             this.m_intError = 0;
             InitializeDatasource();
-
-            //TODO: Delete Conditions, parent plots if only one cond, the cond's trees, etc. all the way through FVSOUT
             if (m_intError == 0)
             {
                 //No specific conditions to remove. Delete all of them.
                 if (this.rdoDeleteAllConds.Checked)
                 {
-                    //LoadMDBPlotCondTreeData_Start();
-                    //MessageBox.Show("You really want to delete everything here?");
-                    //throw new NotImplementedException("This should eventually delete ALL conds/plots/trees through the FVSOUT phase of BioSum.");
-                    //delete pretty much everything. building a string of 1+ biosum_cond_ids is skipped (filter by file radio button not selected)
+                    /*TODO: either set m_strCondCNs to all possible cond.cn values 
+                     * or modify the SQL to skip the where filters 
+                     * (caution: this approach deletes tables that don't have 
+                     * plot/cond/tree/stand identifiers at all)
+                     */
                     DeleteCondsFromBiosumProject_Start();
                 }
                 else if (this.rdoFilterByMenu.Checked)
                 {
-                    //MessageBox.Show("Deleting conds based on menu selection...");
-                    //throw new NotImplementedException("Eventually deletes specific conds/plots/trees through the FVSOUT phase of BioSum.");
+                    //TODO: set m_strCondCNs via the GUI
                     DeleteCondsFromBiosumProject_Start();
                 }
                 else if (this.rdoFilterByFile.Checked)
@@ -211,9 +212,6 @@ namespace FIA_Biosum_Manager
                             this.CreateDelimitedStringList(this.txtFilterByFile.Text.Trim(), ",", ",", false);
                         if (this.m_intError == 0)
                         {
-                            //this.LoadMDBPlotCondTreeData_Start();
-                            //MessageBox.Show("This would be deleting information related to the following conditions:" + m_strCondCNs);
-                            //throw new NotImplementedException("This should eventually delete SPECIFIC conds/plots/trees through the FVSOUT phase of BioSum.");
                             DeleteCondsFromBiosumProject_Start();
                         }
                     }

--- a/src/uc_delete_conditions.cs
+++ b/src/uc_delete_conditions.cs
@@ -1,0 +1,303 @@
+﻿using System;
+using System.Data;
+using System.Windows.Forms;
+
+namespace FIA_Biosum_Manager
+{
+    public partial class uc_delete_conditions : UserControl
+    {
+        public int m_DialogHt;
+        public int m_DialogWd;
+        private DataTable m_dtStateCounty;
+        private DataTable m_dtPlot;
+        private Datasource m_oDatasource;
+        private string m_strPlotTable;
+        private string m_strCondTable;
+        private string m_strTreeTable;
+        private string m_strSiteTreeTable;
+        private string m_strTreeRegionalBiomassTable;
+        private string m_strPpsaTable;
+        private string m_strPopEstUnitTable;
+        private string m_strPopStratumTable;
+        private string m_strPopEvalTable;
+        private string m_strBiosumPopStratumAdjustmentFactorsTable;
+        private string m_strTreeMacroPlotBreakPointDiaTable;
+        //TODO: more strings to hold FVSOUT table information?
+
+        //TODO:for collecting biosum_cond_id values from text file
+		private string m_strBiosumCondIds="";
+
+        //TODO: Help files
+        private env m_oEnv;
+        private Help m_oHelp;
+        private string m_xpsFile = Help.DefaultDatabaseXPSFile;
+        private int m_intError;
+        private string m_strStateCountyPlotSQL;
+        private string m_strStateCountySQL;
+
+        public uc_delete_conditions()
+        {
+            ReferenceFormDialog = null;
+            InitializeComponent();
+            Initialize();
+        }
+
+        private void Initialize()
+        {
+            Width = 700;
+            m_DialogWd = Width + 10;
+            m_DialogHt = groupBox1.Top + grpboxFilter.Top + grpboxFilter.Height + 100;
+
+            grpboxFilterByState.Left = grpboxFilter.Left;
+            grpboxFilterByState.Width = grpboxFilter.Width;
+            grpboxFilterByState.Height = grpboxFilter.Height;
+            grpboxFilterByState.Top = grpboxFilter.Top;
+            btnFilterByStateHelp.Location = btnFilterHelp.Location;
+            btnFilterByStateCancel.Location = btnFilterCancel.Location;
+            btnFilterByStatePrevious.Location = btnFilterPrevious.Location;
+            btnFilterByStateNext.Location = btnFilterNext.Location;
+            btnFilterByStateFinish.Location = btnFilterFinish.Location;
+            grpboxFilterByState.Visible = false;
+
+            grpboxFilterByCondId.Left = grpboxFilter.Left;
+            grpboxFilterByCondId.Width = grpboxFilter.Width;
+            grpboxFilterByCondId.Height = grpboxFilter.Height;
+            grpboxFilterByCondId.Top = grpboxFilter.Top;
+            btnFilterByPlotHelp.Location = btnFilterHelp.Location;
+            btnFilterByPlotCancel.Location = btnFilterCancel.Location;
+            btnFilterByPlotPrevious.Location = btnFilterPrevious.Location;
+            btnFilterByPlotNext.Location = btnFilterNext.Location;
+            btnFilterByPlotFinish.Location = btnFilterFinish.Location;
+            grpboxFilterByCondId.Visible = false;
+
+            lstFilterByState.Clear();
+            lstFilterByState.Columns.Add(" ", 100, HorizontalAlignment.Center);
+            lstFilterByState.Columns.Add("State", 100, HorizontalAlignment.Left);
+            lstFilterByState.Columns.Add("County", 100, HorizontalAlignment.Left);
+
+            //create state,count table
+            m_dtStateCounty = new DataTable("statecounty");
+            m_dtStateCounty.Columns.Add("statecd", typeof(string));
+            m_dtStateCounty.Columns.Add("countycd", typeof(string));
+
+            // two columns in the Primary Key.
+            var colPk = new DataColumn[2];
+            colPk[0] = m_dtStateCounty.Columns["statecd"];
+            colPk[1] = m_dtStateCounty.Columns["countycd"];
+            m_dtStateCounty.PrimaryKey = colPk;
+
+            //create state,county,plot table
+            m_dtPlot = new DataTable("statecountyplot");
+            m_dtPlot.Columns.Add("statecd", typeof(string));
+            m_dtPlot.Columns.Add("countycd", typeof(string));
+            m_dtPlot.Columns.Add("plot", typeof(string));
+
+            m_oEnv = new env();
+        }
+
+        private void InitializeDatasource()
+        {
+            var strProjDir = frmMain.g_oFrmMain.frmProject.uc_project1.txtRootDirectory.Text.Trim();
+
+            m_oDatasource = new Datasource();
+            m_oDatasource.LoadTableColumnNamesAndDataTypes = false;
+            m_oDatasource.LoadTableRecordCount = false;
+            m_oDatasource.m_strDataSourceMDBFile = strProjDir.Trim() + "\\db\\project.mdb";
+            m_oDatasource.m_strDataSourceTableName = "datasource";
+            m_oDatasource.m_strScenarioId = "";
+            m_oDatasource.populate_datasource_array();
+
+            //get table names
+            m_strPlotTable = m_oDatasource.getValidDataSourceTableName("PLOT");
+            m_strCondTable = m_oDatasource.getValidDataSourceTableName("CONDITION");
+            m_strTreeTable = m_oDatasource.getValidDataSourceTableName("TREE");
+            m_strSiteTreeTable = m_oDatasource.getValidDataSourceTableName("SITE TREE");
+            m_strTreeRegionalBiomassTable = m_oDatasource.getValidDataSourceTableName("TREE REGIONAL BIOMASS");
+            m_strPpsaTable = m_oDatasource.getValidDataSourceTableName("POPULATION PLOT STRATUM ASSIGNMENT");
+            m_strPopEstUnitTable = m_oDatasource.getValidDataSourceTableName("POPULATION ESTIMATION UNIT");
+            m_strPopStratumTable = m_oDatasource.getValidDataSourceTableName("POPULATION STRATUM");
+            m_strPopEvalTable = m_oDatasource.getValidDataSourceTableName("POPULATION EVALUATION");
+            m_strBiosumPopStratumAdjustmentFactorsTable =
+                m_oDatasource.getValidDataSourceTableName("BIOSUM POP STRATUM ADJUSTMENT FACTORS");
+            m_strTreeMacroPlotBreakPointDiaTable =
+                m_oDatasource.getValidDataSourceTableName("FIA TREE MACRO PLOT BREAKPOINT DIAMETER");
+        }
+
+        private void rdoFilterByFile_Click(object sender, System.EventArgs e)
+        {
+            this.btnFilterFinish.Enabled = false;
+            this.btnFilterNext.Enabled = false;
+            this.txtFilterByFile.Enabled = true;
+            this.btnFilterByFileBrowse.Enabled = true;
+            if (!string.IsNullOrWhiteSpace(txtFilterByFile.Text))
+            {
+                this.btnFilterFinish.Enabled = true;
+            }
+        }
+
+        private void rdoFilterByMenu_Click(object sender, System.EventArgs e)
+        {
+            this.btnFilterFinish.Enabled = false;
+            this.btnFilterNext.Enabled = true;
+            this.txtFilterByFile.Enabled = false;
+            this.btnFilterByFileBrowse.Enabled = false;
+        }
+
+        private void rdoDeleteAllConds_Click(object sender, System.EventArgs e)
+        {
+
+            this.btnFilterFinish.Enabled = true;
+            this.btnFilterNext.Enabled = true;
+            this.txtFilterByFile.Enabled = false;
+            this.btnFilterByFileBrowse.Enabled = false;
+        }
+
+        private void btnCancel_Click(object sender, System.EventArgs e)
+        {
+            ((frmDialog)this.ParentForm).Close();
+        }
+
+        private void btnFilterFinish_Click(object sender, System.EventArgs e)
+        {
+            this.m_strStateCountyPlotSQL = "";
+            this.m_strStateCountySQL = "";
+            this.m_intError = 0;
+            InitializeDatasource();
+
+            //TODO: Delete Conditions, parent plots if only one cond, the cond's trees, etc. all the way through FVSOUT
+            if (m_intError == 0)
+            {
+                //No specific conditions to remove. Delete all of them.
+                if (this.rdoDeleteAllConds.Checked)
+                {
+                    //LoadMDBPlotCondTreeData_Start();
+                    MessageBox.Show("You really want to delete everything here?");
+//                    throw new NotImplementedException("This should eventually delete ALL conds/plots/trees through the FVSOUT phase of BioSum.");
+                    //delete pretty much everything. building a string of 1+ biosum_cond_ids is skipped (filter by file radio button not selected)
+                    DeleteCondsFromBiosumProject();
+                }
+                else if (this.rdoFilterByMenu.Checked)
+                {
+                    MessageBox.Show("Deleting conds based on menu selection...");
+//                    throw new NotImplementedException("Eventually deletes specific conds/plots/trees through the FVSOUT phase of BioSum.");
+                    DeleteCondsFromBiosumProject();
+                }
+                else if (this.rdoFilterByFile.Checked)
+                {
+                    if (System.IO.File.Exists(this.txtFilterByFile.Text.Trim()) == true)
+                    {
+                        this.m_strBiosumCondIds = this.CreateDelimitedStringList(this.txtFilterByFile.Text.Trim(), ",", ",", false);
+                        if (this.m_intError == 0)
+                        {
+                            //this.LoadMDBPlotCondTreeData_Start();
+                            MessageBox.Show("This would be deleting information related to the following conditions:" + m_strBiosumCondIds);
+//                            throw new NotImplementedException("This should eventually delete SPECIFIC conds/plots/trees through the FVSOUT phase of BioSum.");
+                            DeleteCondsFromBiosumProject();
+                        }
+                    }
+                    else
+                    {
+                        MessageBox.Show("!!" + this.txtFilterByFile.Text.Trim() + " could not be found!!", "Delete Conditions", System.Windows.Forms.MessageBoxButtons.OK, System.Windows.Forms.MessageBoxIcon.Exclamation);
+                    }
+                }
+            }
+        }
+
+        private void DeleteCondsFromBiosumProject()
+        {
+            //throw new NotImplementedException("Delete conds, with or without filters, using m_strBiosumCondIds built with either a text file or GUI menu. use it to collect biosum_cond_ids, plot.cn, tree.cn");
+        }
+
+        public frmDialog ReferenceFormDialog { set; get; }
+
+
+        private void btnFilterByFileBrowse_click(object sender, EventArgs e)
+        {
+            var OpenFileDialog1 = new OpenFileDialog();
+            OpenFileDialog1.Title = "Text File With PLOT_CN data";
+            OpenFileDialog1.Filter = "Text File (*.TXT;*.DAT) |*.txt;*.dat";
+            var result = OpenFileDialog1.ShowDialog();
+            if (result == DialogResult.OK)
+            {
+                if (OpenFileDialog1.FileName.Trim().Length > 0)
+                    txtFilterByFile.Text = OpenFileDialog1.FileName.Trim();
+                OpenFileDialog1 = null;
+            }
+        }
+
+        /// <summary>
+		/// create a delimited string list from a text file
+		/// that has a single column of data with multiple rows
+		/// </summary>
+		/// <param name="p_strTxtFile">text file containing the column of data</param>
+		/// <param name="p_strTxtFileDelimiter">specified character between list items</param>
+		/// <param name="p_strListDelimiter">specified character between list items</param>
+		/// <param name="p_bNumericDataType">specifies if the column data to retrieve in the text file is numeric</param>
+		/// <returns></returns>
+		private string CreateDelimitedStringList(string p_strTxtFile,string p_strTxtFileDelimiter, string p_strListDelimiter,bool p_bNumericDataType)
+		{
+			//The DataSet to Return
+			//DataSet result = new DataSet();
+			this.m_intError=0;
+			string strList="";
+			string str="";
+			try
+			{
+				//Open the file in a stream reader.
+				System.IO.StreamReader s = new System.IO.StreamReader(p_strTxtFile);
+				//Read the rest of the data in the file.        
+				string AllData = s.ReadToEnd();
+    
+				//Split off each row at the Carriage Return/Line Feed
+				//Default line ending in most <A class=iAs style="FONT-WEIGHT: normal; FONT-SIZE: 100%; PADDING-BOTTOM: 1px; COLOR: darkgreen; BORDER-BOTTOM: darkgreen 0.07em solid; BACKGROUND-COLOR: transparent; TEXT-DECORATION: underline" href="#" target=_blank itxtdid="2592535">windows</A> exports.  
+				string[] rows = AllData.Split("\r\n".ToCharArray());
+ 
+				//Now add each row to the DataSet        
+				foreach(string r in rows)
+				{
+					//Split the row at the delimiter.
+					string[] items = r.Split(p_strTxtFileDelimiter.ToCharArray());
+					str = items[0].Trim();  //plot_cn in first column
+					str = str.Replace("\"",""); //remove any quotations
+					if (str.Trim().Length > 0)
+					{
+						if (strList.Trim().Length == 0)
+						{
+							if (p_bNumericDataType == true)
+							{
+								strList = str.Trim();
+							}
+							else
+							{
+								strList = "'" + str.Trim() + "'";
+							}
+						}
+						else
+						{
+							if (p_bNumericDataType == true)
+							{
+								strList = strList + p_strListDelimiter.Trim() + str.Trim();
+							}
+							else
+							{
+								strList = strList + p_strListDelimiter.Trim() + "'" + str.Trim() + "'";
+							}
+
+						}
+					}
+				}
+			}
+			catch (Exception caught)
+			{
+				this.m_intError=-1;
+				MessageBox.Show("!!Error: CreateDelimitedStringList() Routine Error Msg:" + caught.Message);
+			}
+			return strList;
+		}
+
+        private void txtFilterByFile_TextChanged(object sender, EventArgs e)
+        {
+            this.btnFilterFinish.Enabled = true;
+        }
+    }
+}

--- a/src/uc_delete_conditions.resx
+++ b/src/uc_delete_conditions.resx
@@ -1,0 +1,130 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="btnFilterByFileBrowse.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        Qk32AAAAAAAAAHYAAAAoAAAAEAAAABAAAAABAAQAAAAAAAAAAADEDgAAxA4AABAAAAAQAAAAAAAA/wAA
+        gP8AgAD/AICA/4AAAP+AAID/gIAA/4CAgP/AwMD/AAD//wD/AP8A/////wAA//8A/////wD//////4iI
+        iIiIiIiIiIiIiIiIiIiAAAAAAAAACHd3d3d3d3cIf7i4uLi4twh/i4uLi4uHCH+4uLi4uLcIf4uLi4uL
+        hwh/uLi4uLi3CH+Li4uLi4cIf7i4uLi4twh////////3CHi4uLh3d3eIh4uLh4iIiIiId3d4iIiIiIiI
+        iIiIiIiI
+</value>
+  </data>
+</root>

--- a/src/uc_fvs_output.cs
+++ b/src/uc_fvs_output.cs
@@ -605,6 +605,23 @@ namespace FIA_Biosum_Manager
 		}
 
 		#endregion
+	    public bool createFvsCutListIfDNE(string strOutDirAndFile)
+	    {
+	        bool bCutListPresent = true;
+            ado_data_access oAdo = new ado_data_access();
+            oAdo.OpenConnection(oAdo.getMDBConnString(strOutDirAndFile, "", ""));
+	        if (oAdo.TableExist(oAdo.m_OleDbConnection, "FVS_CUTLIST") == false)
+	        {
+	            Tables.FVS.CreateFVSCutListTable(oAdo);
+	            bCutListPresent = false;
+	        }
+            oAdo.CloseConnection(oAdo.m_OleDbConnection);
+            oAdo.m_OleDbConnection.Dispose();
+            oAdo.m_OleDbConnection = null;
+	        oAdo = null;
+	        return bCutListPresent;
+	    }
+
 		public void loadvalues()
 		{
 			
@@ -725,6 +742,7 @@ namespace FIA_Biosum_Manager
 					if (System.IO.File.Exists(strOutDirAndFile) == true)
 					{
 
+					    createFvsCutListIfDNE(strOutDirAndFile);
 						strTableNames = new string[300];						
 						oDao2.getTableNames(strOutDirAndFile,ref strTableNames);
 						for (x=0;x<=strTableNames.Length-1;x++)

--- a/src/uc_plot_add_edit.cs
+++ b/src/uc_plot_add_edit.cs
@@ -29,6 +29,7 @@ namespace FIA_Biosum_Manager
 		public const int TABLESTATUS = 5;
 		public const int RECORDCOUNT = 6;
 		private System.Windows.Forms.ImageList imageList1;
+        private ToolBarButton tblbtnDeleteConds;
 		private System.ComponentModel.IContainer components;
 
 		public uc_plot_add_edit()
@@ -63,99 +64,111 @@ namespace FIA_Biosum_Manager
 		/// </summary>
 		private void InitializeComponent()
 		{
-			this.components = new System.ComponentModel.Container();
-			System.Resources.ResourceManager resources = new System.Resources.ResourceManager(typeof(uc_plot_add_edit));
-			this.btnAdd = new System.Windows.Forms.Button();
-			this.btnEdit = new System.Windows.Forms.Button();
-			this.tlbPlotAddEdit = new System.Windows.Forms.ToolBar();
-			this.tlbbtnAdd = new System.Windows.Forms.ToolBarButton();
-			this.tlbbtnEdit = new System.Windows.Forms.ToolBarButton();
-			this.contextMenu1 = new System.Windows.Forms.ContextMenu();
-			this.mnuEditDeleteAll = new System.Windows.Forms.MenuItem();
-			this.mnuEditBrowse = new System.Windows.Forms.MenuItem();
-			this.imageList1 = new System.Windows.Forms.ImageList(this.components);
-			this.SuspendLayout();
-			// 
-			// btnAdd
-			// 
-			this.btnAdd.Location = new System.Drawing.Point(24, 72);
-			this.btnAdd.Name = "btnAdd";
-			this.btnAdd.Size = new System.Drawing.Size(80, 72);
-			this.btnAdd.TabIndex = 0;
-			this.btnAdd.Text = "Add Plot Data";
-			this.btnAdd.Visible = false;
-			this.btnAdd.Click += new System.EventHandler(this.btnAdd_Click);
-			// 
-			// btnEdit
-			// 
-			this.btnEdit.Location = new System.Drawing.Point(168, 72);
-			this.btnEdit.Name = "btnEdit";
-			this.btnEdit.Size = new System.Drawing.Size(80, 72);
-			this.btnEdit.TabIndex = 1;
-			this.btnEdit.Text = "Edit Plot Data";
-			this.btnEdit.Visible = false;
-			// 
-			// tlbPlotAddEdit
-			// 
-			this.tlbPlotAddEdit.Buttons.AddRange(new System.Windows.Forms.ToolBarButton[] {
-																							  this.tlbbtnAdd,
-																							  this.tlbbtnEdit});
-			this.tlbPlotAddEdit.ButtonSize = new System.Drawing.Size(150, 55);
-			this.tlbPlotAddEdit.Divider = false;
-			this.tlbPlotAddEdit.Dock = System.Windows.Forms.DockStyle.None;
-			this.tlbPlotAddEdit.DropDownArrows = true;
-			this.tlbPlotAddEdit.ImageList = this.imageList1;
-			this.tlbPlotAddEdit.Location = new System.Drawing.Point(8, 8);
-			this.tlbPlotAddEdit.Name = "tlbPlotAddEdit";
-			this.tlbPlotAddEdit.ShowToolTips = true;
-			this.tlbPlotAddEdit.Size = new System.Drawing.Size(352, 59);
-			this.tlbPlotAddEdit.TabIndex = 2;
-			this.tlbPlotAddEdit.ButtonClick += new System.Windows.Forms.ToolBarButtonClickEventHandler(this.tlbPlotAddEdit_ButtonClick);
-			// 
-			// tlbbtnAdd
-			// 
-			this.tlbbtnAdd.ImageIndex = 0;
-			this.tlbbtnAdd.Text = "Add Plot Data";
-			// 
-			// tlbbtnEdit
-			// 
-			this.tlbbtnEdit.DropDownMenu = this.contextMenu1;
-			this.tlbbtnEdit.ImageIndex = 1;
-			this.tlbbtnEdit.Style = System.Windows.Forms.ToolBarButtonStyle.DropDownButton;
-			this.tlbbtnEdit.Text = "Delete Plot Data";
-			// 
-			// contextMenu1
-			// 
-			this.contextMenu1.MenuItems.AddRange(new System.Windows.Forms.MenuItem[] {
-																						 this.mnuEditDeleteAll,
-																						 this.mnuEditBrowse});
-			// 
-			// mnuEditDeleteAll
-			// 
-			this.mnuEditDeleteAll.Index = 0;
-			this.mnuEditDeleteAll.Text = "Delete All Plot Records";
-			this.mnuEditDeleteAll.Click += new System.EventHandler(this.mnuEditDeleteAll_Click);
-			// 
-			// mnuEditBrowse
-			// 
-			this.mnuEditBrowse.Index = 1;
-			this.mnuEditBrowse.Text = "Browse And Delete Selected Plot Records";
-			this.mnuEditBrowse.Click += new System.EventHandler(this.mnuEditBrowse_Click);
-			// 
-			// imageList1
-			// 
-			this.imageList1.ImageSize = new System.Drawing.Size(30, 30);
-			this.imageList1.ImageStream = ((System.Windows.Forms.ImageListStreamer)(resources.GetObject("imageList1.ImageStream")));
-			this.imageList1.TransparentColor = System.Drawing.Color.Transparent;
-			// 
-			// uc_plot_add_edit
-			// 
-			this.Controls.Add(this.tlbPlotAddEdit);
-			this.Controls.Add(this.btnEdit);
-			this.Controls.Add(this.btnAdd);
-			this.Name = "uc_plot_add_edit";
-			this.Size = new System.Drawing.Size(344, 72);
-			this.ResumeLayout(false);
+            this.components = new System.ComponentModel.Container();
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(uc_plot_add_edit));
+            this.btnAdd = new System.Windows.Forms.Button();
+            this.btnEdit = new System.Windows.Forms.Button();
+            this.tlbPlotAddEdit = new System.Windows.Forms.ToolBar();
+            this.tlbbtnAdd = new System.Windows.Forms.ToolBarButton();
+            this.tlbbtnEdit = new System.Windows.Forms.ToolBarButton();
+            this.contextMenu1 = new System.Windows.Forms.ContextMenu();
+            this.mnuEditDeleteAll = new System.Windows.Forms.MenuItem();
+            this.mnuEditBrowse = new System.Windows.Forms.MenuItem();
+            this.imageList1 = new System.Windows.Forms.ImageList(this.components);
+            this.tblbtnDeleteConds = new System.Windows.Forms.ToolBarButton();
+            this.SuspendLayout();
+            // 
+            // btnAdd
+            // 
+            this.btnAdd.Location = new System.Drawing.Point(24, 72);
+            this.btnAdd.Name = "btnAdd";
+            this.btnAdd.Size = new System.Drawing.Size(80, 72);
+            this.btnAdd.TabIndex = 0;
+            this.btnAdd.Text = "Add Plot Data";
+            this.btnAdd.Visible = false;
+            this.btnAdd.Click += new System.EventHandler(this.btnAdd_Click);
+            // 
+            // btnEdit
+            // 
+            this.btnEdit.Location = new System.Drawing.Point(168, 72);
+            this.btnEdit.Name = "btnEdit";
+            this.btnEdit.Size = new System.Drawing.Size(80, 72);
+            this.btnEdit.TabIndex = 1;
+            this.btnEdit.Text = "Edit Plot Data";
+            this.btnEdit.Visible = false;
+            // 
+            // tlbPlotAddEdit
+            // 
+            this.tlbPlotAddEdit.Buttons.AddRange(new System.Windows.Forms.ToolBarButton[] {
+            this.tlbbtnAdd,
+            this.tblbtnDeleteConds,
+            this.tlbbtnEdit});
+            this.tlbPlotAddEdit.ButtonSize = new System.Drawing.Size(150, 55);
+            this.tlbPlotAddEdit.Divider = false;
+            this.tlbPlotAddEdit.Dock = System.Windows.Forms.DockStyle.None;
+            this.tlbPlotAddEdit.DropDownArrows = true;
+            this.tlbPlotAddEdit.ImageList = this.imageList1;
+            this.tlbPlotAddEdit.Location = new System.Drawing.Point(5, 5);
+            this.tlbPlotAddEdit.Name = "tlbPlotAddEdit";
+            this.tlbPlotAddEdit.ShowToolTips = true;
+            this.tlbPlotAddEdit.Size = new System.Drawing.Size(495, 62);
+            this.tlbPlotAddEdit.TabIndex = 2;
+            this.tlbPlotAddEdit.ButtonClick += new System.Windows.Forms.ToolBarButtonClickEventHandler(this.tlbPlotAddEdit_ButtonClick);
+            // 
+            // tlbbtnAdd
+            // 
+            this.tlbbtnAdd.ImageIndex = 0;
+            this.tlbbtnAdd.Name = "tlbbtnAdd";
+            this.tlbbtnAdd.Text = "Add Plot Data";
+            // 
+            // tlbbtnEdit
+            // 
+            this.tlbbtnEdit.DropDownMenu = this.contextMenu1;
+            this.tlbbtnEdit.ImageIndex = 1;
+            this.tlbbtnEdit.Name = "tlbbtnEdit";
+            this.tlbbtnEdit.Style = System.Windows.Forms.ToolBarButtonStyle.DropDownButton;
+            this.tlbbtnEdit.Text = "Delete Plot Data";
+            // 
+            // contextMenu1
+            // 
+            this.contextMenu1.MenuItems.AddRange(new System.Windows.Forms.MenuItem[] {
+            this.mnuEditDeleteAll,
+            this.mnuEditBrowse});
+            // 
+            // mnuEditDeleteAll
+            // 
+            this.mnuEditDeleteAll.Index = 0;
+            this.mnuEditDeleteAll.Text = "Delete All Plot Records";
+            this.mnuEditDeleteAll.Click += new System.EventHandler(this.mnuEditDeleteAll_Click);
+            // 
+            // mnuEditBrowse
+            // 
+            this.mnuEditBrowse.Index = 1;
+            this.mnuEditBrowse.Text = "Browse And Delete Selected Plot Records";
+            this.mnuEditBrowse.Click += new System.EventHandler(this.mnuEditBrowse_Click);
+            // 
+            // imageList1
+            // 
+            this.imageList1.ImageStream = ((System.Windows.Forms.ImageListStreamer)(resources.GetObject("imageList1.ImageStream")));
+            this.imageList1.TransparentColor = System.Drawing.Color.Transparent;
+            this.imageList1.Images.SetKeyName(0, "");
+            this.imageList1.Images.SetKeyName(1, "");
+            // 
+            // tblbtnDeleteConds
+            // 
+            this.tblbtnDeleteConds.ImageIndex = 1;
+            this.tblbtnDeleteConds.Name = "tblbtnDeleteConds";
+            this.tblbtnDeleteConds.Text = "Delete Conditions";
+            // 
+            // uc_plot_add_edit
+            // 
+            this.Controls.Add(this.tlbPlotAddEdit);
+            this.Controls.Add(this.btnEdit);
+            this.Controls.Add(this.btnAdd);
+            this.Name = "uc_plot_add_edit";
+            this.Size = new System.Drawing.Size(505, 72);
+            this.ResumeLayout(false);
+            this.PerformLayout();
 
 		}
 		#endregion
@@ -205,10 +218,29 @@ namespace FIA_Biosum_Manager
                     frmTemp.MinimizeMainForm = true;
                     frmTemp.ParentControl = frmMain.g_oFrmMain;
                     frmTemp.ParentControl.Enabled = false;
-                    
 					frmTemp.Show();
-
 					break;
+
+				case "DELETE CONDITIONS":
+					frmDialog frmTemp2 = new frmDialog(((frmDialog)this.ParentForm).m_frmMain);
+					frmTemp2.Visible=false;
+					frmTemp2.Initialize_Delete_Conditions_User_Control();
+					frmTemp2.MaximizeBox = false;
+					frmTemp2.MinimizeBox = true;
+					frmTemp2.Width = frmTemp2.uc_delete_conditions.m_DialogWd;
+					frmTemp2.Height = frmTemp2.uc_delete_conditions.m_DialogHt;
+					frmTemp2.Text = "Database: Delete Conditions";
+					frmTemp2.uc_delete_conditions.Dock = System.Windows.Forms.DockStyle.Fill;
+					frmTemp2.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+					frmTemp2.uc_delete_conditions.Visible=true;
+					frmTemp2.DisposeOfFormWhenClosing=true;
+                    frmTemp2.uc_delete_conditions.ReferenceFormDialog = frmTemp2;
+                    frmTemp2.MinimizeMainForm = true;
+                    frmTemp2.ParentControl = frmMain.g_oFrmMain;
+                    frmTemp2.ParentControl.Enabled = false;
+					frmTemp2.Show();
+					break;
+
                 case "BROWSE AND DELETE SELECTED PLOT RECORDS":
 					//instantiate the datasource class
 					FIA_Biosum_Manager.Datasource p_datasource = new Datasource(((frmDialog)this.ParentForm).m_frmMain.frmProject.uc_project1.txtRootDirectory.Text.Trim());

--- a/src/uc_plot_add_edit.resx
+++ b/src/uc_plot_add_edit.resx
@@ -3,7 +3,7 @@
   <!-- 
     Microsoft ResX Schema 
     
-    Version 1.3
+    Version 2.0
     
     The primary goals of this format is to allow a simple XML format 
     that is mostly human readable. The generation and parsing of the 
@@ -14,16 +14,17 @@
     
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
-    <resheader name="version">1.3</resheader>
+    <resheader name="version">2.0</resheader>
     <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
     <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
-    <data name="Name1">this is my long string</data>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
     <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
     <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
-        [base64 mime encoded serialized .NET Framework object]
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
     </data>
     <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-        [base64 mime encoded string representing a byte array form of the .NET Framework object]
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
     </data>
                 
     There are any number of "resheader" rows that contain simple 
@@ -35,7 +36,7 @@
     Classes that don't support this are serialized and stored with the 
     mimetype set.
     
-    The mimetype is used forserialized objects, and tells the 
+    The mimetype is used for serialized objects, and tells the 
     ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
     
@@ -45,7 +46,7 @@
     
     mimetype: application/x-microsoft.net.object.binary.base64
     value   : The object must be serialized with 
-            : System.Serialization.Formatters.Binary.BinaryFormatter
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
     
     mimetype: application/x-microsoft.net.object.soap.base64
@@ -59,18 +60,37 @@
             : and then encoded with base64 encoding.
     -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
           <xsd:element name="data">
             <xsd:complexType>
               <xsd:sequence>
                 <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
                 <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" msdata:Ordinal="1" />
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
               <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
               <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="resheader">
@@ -89,173 +109,79 @@
     <value>text/microsoft-resx</value>
   </resheader>
   <resheader name="version">
-    <value>1.3</value>
+    <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=1.0.5000.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=1.0.5000.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="btnAdd.Locked" type="System.Boolean, mscorlib, Version=1.0.5000.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>False</value>
-  </data>
-  <data name="btnAdd.DefaultModifiers" type="System.CodeDom.MemberAttributes, System, Version=1.0.5000.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>Private</value>
-  </data>
-  <data name="btnAdd.Modifiers" type="System.CodeDom.MemberAttributes, System, Version=1.0.5000.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>Private</value>
-  </data>
-  <data name="btnEdit.Locked" type="System.Boolean, mscorlib, Version=1.0.5000.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>False</value>
-  </data>
-  <data name="btnEdit.DefaultModifiers" type="System.CodeDom.MemberAttributes, System, Version=1.0.5000.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>Private</value>
-  </data>
-  <data name="btnEdit.Modifiers" type="System.CodeDom.MemberAttributes, System, Version=1.0.5000.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>Private</value>
-  </data>
-  <data name="tlbPlotAddEdit.Locked" type="System.Boolean, mscorlib, Version=1.0.5000.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>False</value>
-  </data>
-  <data name="tlbPlotAddEdit.DefaultModifiers" type="System.CodeDom.MemberAttributes, System, Version=1.0.5000.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>Private</value>
-  </data>
-  <data name="tlbPlotAddEdit.Modifiers" type="System.CodeDom.MemberAttributes, System, Version=1.0.5000.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>Private</value>
-  </data>
-  <data name="tlbbtnAdd.Modifiers" type="System.CodeDom.MemberAttributes, System, Version=1.0.5000.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>Private</value>
-  </data>
-  <data name="tlbbtnAdd.DefaultModifiers" type="System.CodeDom.MemberAttributes, System, Version=1.0.5000.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>Private</value>
-  </data>
-  <data name="tlbbtnEdit.Modifiers" type="System.CodeDom.MemberAttributes, System, Version=1.0.5000.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>Private</value>
-  </data>
-  <data name="tlbbtnEdit.DefaultModifiers" type="System.CodeDom.MemberAttributes, System, Version=1.0.5000.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>Private</value>
-  </data>
-  <data name="contextMenu1.DefaultModifiers" type="System.CodeDom.MemberAttributes, System, Version=1.0.5000.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>Private</value>
-  </data>
-  <data name="contextMenu1.Location" type="System.Drawing.Point, System.Drawing, Version=1.0.5000.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="contextMenu1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
-  </data>
-  <data name="contextMenu1.Modifiers" type="System.CodeDom.MemberAttributes, System, Version=1.0.5000.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>Private</value>
-  </data>
-  <data name="mnuEditDeleteAll.Modifiers" type="System.CodeDom.MemberAttributes, System, Version=1.0.5000.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>Private</value>
-  </data>
-  <data name="mnuEditDeleteAll.DefaultModifiers" type="System.CodeDom.MemberAttributes, System, Version=1.0.5000.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>Private</value>
-  </data>
-  <data name="mnuEditBrowse.Modifiers" type="System.CodeDom.MemberAttributes, System, Version=1.0.5000.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>Private</value>
-  </data>
-  <data name="mnuEditBrowse.DefaultModifiers" type="System.CodeDom.MemberAttributes, System, Version=1.0.5000.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>Private</value>
-  </data>
-  <data name="imageList1.Modifiers" type="System.CodeDom.MemberAttributes, System, Version=1.0.5000.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>Private</value>
-  </data>
-  <data name="imageList1.DefaultModifiers" type="System.CodeDom.MemberAttributes, System, Version=1.0.5000.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>Private</value>
-  </data>
-  <data name="imageList1.Location" type="System.Drawing.Point, System.Drawing, Version=1.0.5000.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  </metadata>
+  <metadata name="imageList1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>139, 17</value>
-  </data>
+  </metadata>
   <data name="imageList1.ImageStream" mimetype="application/x-microsoft.net.object.binary.base64">
     <value>
-        AAEAAAD/////AQAAAAAAAAAMAgAAAFpTeXN0ZW0uV2luZG93cy5Gb3JtcywgVmVyc2lvbj0xLjAuNTAw
-        MC4wLCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODkFAQAAACZT
-        eXN0ZW0uV2luZG93cy5Gb3Jtcy5JbWFnZUxpc3RTdHJlYW1lcgEAAAAERGF0YQcCAgAAAAkDAAAADwMA
-        AACmDAAAAk1TRnQBSQFMAgEBAgEAAQUBAAEEAQABHgEAAR4BAAT/AQkBEAj/AUIBTQE2AQQGAAE2AQQC
-        AAEoAwABeAMAATwDAAEBAQABCAUAASABHBgAAYACAAGAAwACgAEAAYADAAGAAQABgAEAAoACAAPAAQAB
-        wAHcAcABAAHwAcoBpgEAATMFAAEzAQABMwEAATMBAAIzAgADFgEAAxwBAAMiAQADKQEAA1UBAANNAQAD
-        QgEAAzkBAAGAAXwB/wEAAlAB/wEAAZMBAAHWAQAB/wHsAcwBAAHGAdYB7wEAAdYC5wEAAZABqQGtAgAB
-        /wEzAwABZgMAAZkDAAHMAgABMwMAAjMCAAEzAWYCAAEzAZkCAAEzAcwCAAEzAf8CAAFmAwABZgEzAgAC
-        ZgIAAWYBmQIAAWYBzAIAAWYB/wIAAZkDAAGZATMCAAGZAWYCAAKZAgABmQHMAgABmQH/AgABzAMAAcwB
-        MwIAAcwBZgIAAcwBmQIAAswCAAHMAf8CAAH/AWYCAAH/AZkCAAH/AcwBAAEzAf8CAAH/AQABMwEAATMB
-        AAFmAQABMwEAAZkBAAEzAQABzAEAATMBAAH/AQAB/wEzAgADMwEAAjMBZgEAAjMBmQEAAjMBzAEAAjMB
-        /wEAATMBZgIAATMBZgEzAQABMwJmAQABMwFmAZkBAAEzAWYBzAEAATMBZgH/AQABMwGZAgABMwGZATMB
-        AAEzAZkBZgEAATMCmQEAATMBmQHMAQABMwGZAf8BAAEzAcwCAAEzAcwBMwEAATMBzAFmAQABMwHMAZkB
-        AAEzAswBAAEzAcwB/wEAATMB/wEzAQABMwH/AWYBAAEzAf8BmQEAATMB/wHMAQABMwL/AQABZgMAAWYB
-        AAEzAQABZgEAAWYBAAFmAQABmQEAAWYBAAHMAQABZgEAAf8BAAFmATMCAAFmAjMBAAFmATMBZgEAAWYB
-        MwGZAQABZgEzAcwBAAFmATMB/wEAAmYCAAJmATMBAANmAQACZgGZAQACZgHMAQABZgGZAgABZgGZATMB
-        AAFmAZkBZgEAAWYCmQEAAWYBmQHMAQABZgGZAf8BAAFmAcwCAAFmAcwBMwEAAWYBzAGZAQABZgLMAQAB
-        ZgHMAf8BAAFmAf8CAAFmAf8BMwEAAWYB/wGZAQABZgH/AcwBAAHMAQAB/wEAAf8BAAHMAQACmQIAAZkB
-        MwGZAQABmQEAAZkBAAGZAQABzAEAAZkDAAGZAjMBAAGZAQABZgEAAZkBMwHMAQABmQEAAf8BAAGZAWYC
-        AAGZAWYBMwEAAZkBMwFmAQABmQFmAZkBAAGZAWYBzAEAAZkBMwH/AQACmQEzAQACmQFmAQADmQEAApkB
-        zAEAApkB/wEAAZkBzAIAAZkBzAEzAQABZgHMAWYBAAGZAcwBmQEAAZkCzAEAAZkBzAH/AQABmQH/AgAB
-        mQH/ATMBAAGZAcwBZgEAAZkB/wGZAQABmQH/AcwBAAGZAv8BAAHMAwABmQEAATMBAAHMAQABZgEAAcwB
-        AAGZAQABzAEAAcwBAAGZATMCAAHMAjMBAAHMATMBZgEAAcwBMwGZAQABzAEzAcwBAAHMATMB/wEAAcwB
-        ZgIAAcwBZgEzAQABmQJmAQABzAFmAZkBAAHMAWYBzAEAAZkBZgH/AQABzAGZAgABzAGZATMBAAHMAZkB
-        ZgEAAcwCmQEAAcwBmQHMAQABzAGZAf8BAALMAgACzAEzAQACzAFmAQACzAGZAQADzAEAAswB/wEAAcwB
-        /wIAAcwB/wEzAQABmQH/AWYBAAHMAf8BmQEAAcwB/wHMAQABzAL/AQABzAEAATMBAAH/AQABZgEAAf8B
-        AAGZAQABzAEzAgAB/wIzAQAB/wEzAWYBAAH/ATMBmQEAAf8BMwHMAQAB/wEzAf8BAAH/AWYCAAH/AWYB
-        MwEAAcwCZgEAAf8BZgGZAQAB/wFmAcwBAAHMAWYB/wEAAf8BmQIAAf8BmQEzAQAB/wGZAWYBAAH/ApkB
-        AAH/AZkBzAEAAf8BmQH/AQAB/wHMAgAB/wHMATMBAAH/AcwBZgEAAf8BzAGZAQAB/wLMAQAB/wHMAf8B
-        AAL/ATMBAAHMAf8BZgEAAv8BmQEAAv8BzAEAAmYB/wEAAWYB/wFmAQABZgL/AQAB/wJmAQAB/wFmAf8B
-        AAL/AWYBAAEhAQABpQEAA18BAAN3AQADhgEAA5YBAAPLAQADsgEAA9cBAAPdAQAD4wEAA+oBAAPxAQAD
-        +AEAAfAB+wH/AQABpAKgAQADgAMAAf8CAAH/AwAC/wEAAf8DAAH/AQAB/wEAAv8CAAP//wD/AP8A/wD/
-        AP8A/wD/AP8A/wD/AP8A/wD/AB8AHv8d1gHPPAAM/wHyD/Ef/wHWPAAM/wFDBhABEQdDAQ4B8R7/AdY8
-        AAz/AUMB9wUHAfAH/wFDAfEe/wHWPAAC/wrvARABbQTsAQcB7wHwAfIB8wLwAfQB/wFDAfEP/wHzApQB
-        vQf/Ar0C/wHWPAAB/wHzAQ4ObQEPAQcB9wHvAfAB8QLvAfIB/wFDAfEP/wGUAvkBFwf/AhcC/wHWPAAB
-        /wHzARAN/wHzAQ8BBwHvAQcB8QHyAgcB8wH/AUMB8Q//AZQC+QFHARcBvQP/Ab0BFwGUAb0C/wHWPAAB
-        /wHzARAB/wHzAgcC8QIHAfMBvAIHAf8B8wEPAQcB7wEHAfEB8gIHAfMB/wFDAfEP/wG9ARcBRwL5AZQC
-        /wG9ARYB+QGUA/8B1jwAAf8B8wEQAf8B9AK8AvICvAH0AfACvAH/AfMBDwEHAfcB7wHwAfEC7wHyAf8B
-        QwHxEf8BFwL5AZQC/wEXAvkBlAP/AdY8AAH/AfMBEAH/AfMC7wLwAu8B8wEHAu8B/wHzAQ8BBwHvAfAB
-        8gHzAvAB9AH/AUMB8QP/AQcNEgFEAh4BRgIXAkcBlAHzA/8B1jwAAf8B8wEQAf8B9ALxAvMC8QH0AfIC
-        8QH/AfMBDwHvAe0B9wEHAfAC9wHxAf8BQwHxA/8B7wEAARUMEgEUAR4BIAL5AUcBlAX/AdY8AAH/AfMB
-        EAH/AfICkgK8ApIB8gHvApIB/wHzAQ8CBwHyAvQC8gH0Af8BQwHsA/8B7wEAAe8M/wGUBPkBlAb/AdY8
-        AAH/AfMBEAL/AvMC9ALzAf8B9ALzAf8B8wEPAQcB8Ab/AeoBAAEOAfMC/wHvAQAB7wEHAhIB7AH/AewC
-        EgIHARIB7wGTBPkBRwGUBf8B1jwAAf8B8wEQAf8B8QLsAgcC7AHxAfcC7AH/AfMBAAcEAQoDAAHzAv8B
-        7wEAAe8BBwISAewB/wHsAhICBwESAW4BFwH5AUcCFwH5AUcBlAHzA/8B1jwAAf8B8wEQDf8B8wEABgQB
-        CgMAAfED/wHvAQAB7wv/ARcC+QGTAgcBFwL5AZQD/wHWPAAB/wHzAREN9AHxAQoFBAEKAgABDgEEAfID
-        /wHvAQABhgjmAbUBkwEXAYIChwGnAsgBtgKUARYBlAL/AdY8AAH/AfQPBAGGAu8BBwHvAeoCAAEOAQcF
-        /wEHARIBpwHIB+YBjQJGAakD5gHIAfwB1gL/ApQC/wHWPAAB/wH0EAQDkgHqAgABDwEHCP8C5gf/ARcB
-        RgHsAfAD/wHWAfwB1gb/AdY8AAH/AfUPhgGuAfEB8AH4AgABEAHvCf8C5gH/AewCEgIHARIBRAFFAfAB
-        7AISAQcB1gH8AdYG/wHWPAAH/wLsAf8BBwLvAfQD7wH0AZIBFQMAAewK/wLmAf8B7AISAgcCEgHsAf8B
-        7AISAQcB1gH8AdYG/wHWPAAH/wLsCP8B9AH4AgABEQFDAewK/wLmDv8B1gH8AdYG/wHWPAAH/wHtAYYI
-        tQHrAwABZgGGAe0K/wHmAcgO5gHIAfwB1gb/AdY8AAf/AbUIBAEKAQMCAAFfAgQBtQr/AeYB/AHIA/wC
-        yAP8AcgD/ALIAfwB1gb/AdY8AAf/AbUHBAEKATABNwEAAV8DBAG1BP8BbwH1BP8B5gHIAQcByAL8ArUC
-        /AHIAQcByAL8ArUB/AHWBv8B1jwAB/8B8Qa1AQoBMAH7ASkB7wS1AfEB/wGTARoB/wEHBf8B5gH8AcgD
-        /ALIA/wByAP8AsgB/AHWBv8B1jwADv8BbQIiAQcC/wEaAZMB/wGTAQcBGgH0B/8B1hHmAd0G/wHWPAAO
-        /wHyAbwB8AHzAW4B/wH0AfMB/wHzAfQC/wFuAfMe/wHWPAAS/wHzAv8CkwL/AW8BGgHzH/8B1jwAFv8B
-        9QL/AfUh/wHWPAA7/wHWPAABQgFNAT4HAAE+AwABKAMAAXgDAAE8AwABAQEAAQEFAAHAAQMWAAP//wD/
-        AP8A2gAL
+        AAEAAAD/////AQAAAAAAAAAMAgAAAFdTeXN0ZW0uV2luZG93cy5Gb3JtcywgVmVyc2lvbj00LjAuMC4w
+        LCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODkFAQAAACZTeXN0
+        ZW0uV2luZG93cy5Gb3Jtcy5JbWFnZUxpc3RTdHJlYW1lcgEAAAAERGF0YQcCAgAAAAkDAAAADwMAAAB6
+        DAAAAk1TRnQBSQFMAgEBAgEAAQwBAAEMAQABHgEAAR4BAAT/AQkBAAj/AUIBTQE2AQQGAAE2AQQCAAEo
+        AwABeAMAAR4DAAEBAQABCAUAARABDhgAAYACAAGAAwACgAEAAYADAAGAAQABgAEAAoACAAPAAQABwAHc
+        AcABAAHwAcoBpgEAATMFAAEzAQABMwEAATMBAAIzAgADFgEAAxwBAAMiAQADKQEAA1UBAANNAQADQgEA
+        AzkBAAGAAXwB/wEAAlAB/wEAAZMBAAHWAQAB/wHsAcwBAAHGAdYB7wEAAdYC5wEAAZABqQGtAgAB/wEz
+        AwABZgMAAZkDAAHMAgABMwMAAjMCAAEzAWYCAAEzAZkCAAEzAcwCAAEzAf8CAAFmAwABZgEzAgACZgIA
+        AWYBmQIAAWYBzAIAAWYB/wIAAZkDAAGZATMCAAGZAWYCAAKZAgABmQHMAgABmQH/AgABzAMAAcwBMwIA
+        AcwBZgIAAcwBmQIAAswCAAHMAf8CAAH/AWYCAAH/AZkCAAH/AcwBAAEzAf8CAAH/AQABMwEAATMBAAFm
+        AQABMwEAAZkBAAEzAQABzAEAATMBAAH/AQAB/wEzAgADMwEAAjMBZgEAAjMBmQEAAjMBzAEAAjMB/wEA
+        ATMBZgIAATMBZgEzAQABMwJmAQABMwFmAZkBAAEzAWYBzAEAATMBZgH/AQABMwGZAgABMwGZATMBAAEz
+        AZkBZgEAATMCmQEAATMBmQHMAQABMwGZAf8BAAEzAcwCAAEzAcwBMwEAATMBzAFmAQABMwHMAZkBAAEz
+        AswBAAEzAcwB/wEAATMB/wEzAQABMwH/AWYBAAEzAf8BmQEAATMB/wHMAQABMwL/AQABZgMAAWYBAAEz
+        AQABZgEAAWYBAAFmAQABmQEAAWYBAAHMAQABZgEAAf8BAAFmATMCAAFmAjMBAAFmATMBZgEAAWYBMwGZ
+        AQABZgEzAcwBAAFmATMB/wEAAmYCAAJmATMBAANmAQACZgGZAQACZgHMAQABZgGZAgABZgGZATMBAAFm
+        AZkBZgEAAWYCmQEAAWYBmQHMAQABZgGZAf8BAAFmAcwCAAFmAcwBMwEAAWYBzAGZAQABZgLMAQABZgHM
+        Af8BAAFmAf8CAAFmAf8BMwEAAWYB/wGZAQABZgH/AcwBAAHMAQAB/wEAAf8BAAHMAQACmQIAAZkBMwGZ
+        AQABmQEAAZkBAAGZAQABzAEAAZkDAAGZAjMBAAGZAQABZgEAAZkBMwHMAQABmQEAAf8BAAGZAWYCAAGZ
+        AWYBMwEAAZkBMwFmAQABmQFmAZkBAAGZAWYBzAEAAZkBMwH/AQACmQEzAQACmQFmAQADmQEAApkBzAEA
+        ApkB/wEAAZkBzAIAAZkBzAEzAQABZgHMAWYBAAGZAcwBmQEAAZkCzAEAAZkBzAH/AQABmQH/AgABmQH/
+        ATMBAAGZAcwBZgEAAZkB/wGZAQABmQH/AcwBAAGZAv8BAAHMAwABmQEAATMBAAHMAQABZgEAAcwBAAGZ
+        AQABzAEAAcwBAAGZATMCAAHMAjMBAAHMATMBZgEAAcwBMwGZAQABzAEzAcwBAAHMATMB/wEAAcwBZgIA
+        AcwBZgEzAQABmQJmAQABzAFmAZkBAAHMAWYBzAEAAZkBZgH/AQABzAGZAgABzAGZATMBAAHMAZkBZgEA
+        AcwCmQEAAcwBmQHMAQABzAGZAf8BAALMAgACzAEzAQACzAFmAQACzAGZAQADzAEAAswB/wEAAcwB/wIA
+        AcwB/wEzAQABmQH/AWYBAAHMAf8BmQEAAcwB/wHMAQABzAL/AQABzAEAATMBAAH/AQABZgEAAf8BAAGZ
+        AQABzAEzAgAB/wIzAQAB/wEzAWYBAAH/ATMBmQEAAf8BMwHMAQAB/wEzAf8BAAH/AWYCAAH/AWYBMwEA
+        AcwCZgEAAf8BZgGZAQAB/wFmAcwBAAHMAWYB/wEAAf8BmQIAAf8BmQEzAQAB/wGZAWYBAAH/ApkBAAH/
+        AZkBzAEAAf8BmQH/AQAB/wHMAgAB/wHMATMBAAH/AcwBZgEAAf8BzAGZAQAB/wLMAQAB/wHMAf8BAAL/
+        ATMBAAHMAf8BZgEAAv8BmQEAAv8BzAEAAmYB/wEAAWYB/wFmAQABZgL/AQAB/wJmAQAB/wFmAf8BAAL/
+        AWYBAAEhAQABpQEAA18BAAN3AQADhgEAA5YBAAPLAQADsgEAA9cBAAPdAQAD4wEAA+oBAAPxAQAD+AEA
+        AfAB+wH/AQABpAKgAQADgAMAAf8CAAH/AwAC/wEAAf8DAAH/AQAB/wEAAv8CAAP/AQAe/x3WAc88AAz/
+        AfIP8R//AdY8AAz/AUMGEAERB0MBDgHxHv8B1jwADP8BQwH3BQcB8Af/AUMB8R7/AdY8AAL/Cu8BEAFt
+        BOwBBwHvAfAB8gHzAvAB9AH/AUMB8Q//AfMClAG9B/8CvQL/AdY8AAH/AfMBDg5tAQ8BBwH3Ae8B8AHx
+        Au8B8gH/AUMB8Q//AZQC+QEXB/8CFwL/AdY8AAH/AfMBEA3/AfMBDwEHAe8BBwHxAfICBwHzAf8BQwHx
+        D/8BlAL5AUcBFwG9A/8BvQEXAZQBvQL/AdY8AAH/AfMBEAH/AfMCBwLxAgcB8wG8AgcB/wHzAQ8BBwHv
+        AQcB8QHyAgcB8wH/AUMB8Q//Ab0BFwFHAvkBlAL/Ab0BFgH5AZQD/wHWPAAB/wHzARAB/wH0ArwC8gK8
+        AfQB8AK8Af8B8wEPAQcB9wHvAfAB8QLvAfIB/wFDAfER/wEXAvkBlAL/ARcC+QGUA/8B1jwAAf8B8wEQ
+        Af8B8wLvAvAC7wHzAQcC7wH/AfMBDwEHAe8B8AHyAfMC8AH0Af8BQwHxA/8BBw0SAUQCHgFGAhcCRwGU
+        AfMD/wHWPAAB/wHzARAB/wH0AvEC8wLxAfQB8gLxAf8B8wEPAe8B7QH3AQcB8AL3AfEB/wFDAfED/wHv
+        AQABFQwSARQBHgEgAvkBRwGUBf8B1jwAAf8B8wEQAf8B8gKSArwCkgHyAe8CkgH/AfMBDwIHAfIC9ALy
+        AfQB/wFDAewD/wHvAQAB7wz/AZQE+QGUBv8B1jwAAf8B8wEQAv8C8wL0AvMB/wH0AvMB/wHzAQ8BBwHw
+        Bv8B6gEAAQ4B8wL/Ae8BAAHvAQcCEgHsAf8B7AISAgcBEgHvAZME+QFHAZQF/wHWPAAB/wHzARAB/wHx
+        AuwCBwLsAfEB9wLsAf8B8wEABwQBCgMAAfMC/wHvAQAB7wEHAhIB7AH/AewCEgIHARIBbgEXAfkBRwIX
+        AfkBRwGUAfMD/wHWPAAB/wHzARAN/wHzAQAGBAEKAwAB8QP/Ae8BAAHvC/8BFwL5AZMCBwEXAvkBlAP/
+        AdY8AAH/AfMBEQ30AfEBCgUEAQoCAAEOAQQB8gP/Ae8BAAGGCOYBtQGTARcBggKHAacCyAG2ApQBFgGU
+        Av8B1jwAAf8B9A8EAYYC7wEHAe8B6gIAAQ4BBwX/AQcBEgGnAcgH5gGNAkYBqQPmAcgB/AHWAv8ClAL/
+        AdY8AAH/AfQQBAOSAeoCAAEPAQcI/wLmB/8BFwFGAewB8AP/AdYB/AHWBv8B1jwAAv8PhgGuAfEB8AHs
+        AgABEAHvCf8C5gH/AewCEgIHARIBRAFFAfAB7AISAQcB1gH8AdYG/wHWPAAH/wLsAf8BBwLvAfQD7wH0
+        AZIBFQMAAewK/wLmAf8B7AISAgcCEgHsAf8B7AISAQcB1gH8AdYG/wHWPAAH/wLsCP8B9AHsAgABEQFD
+        AewK/wLmDv8B1gH8AdYG/wHWPAAH/wHtAYYItQHrAwABZgGGAe0K/wHmAcgO5gHIAfwB1gb/AdY8AAf/
+        AbUIBAEKAQMCAAFfAgQBtQr/AeYB/AHIA/wCyAP8AcgD/ALIAfwB1gb/AdY8AAf/AbUHBAEKATABNwEA
+        AV8DBAG1BP8BbwX/AeYByAEHAcgC/AK1AvwByAEHAcgC/AK1AfwB1gb/AdY8AAf/AfEGtQEKATAB+wEp
+        Ae8EtQHxAf8BkwEaAf8BBwX/AeYB/AHIA/wCyAP8AcgD/ALIAfwB1gb/AdY8AA7/AW0CIgEHAv8BGgGT
+        Af8BkwEHARoB9Af/AdYR5gHdBv8B1jwADv8B8gG8AfAB8wFuAf8B9AHzAf8B8wH0Av8BbgHzHv8B1jwA
+        Ev8B8wL/ApMC/wFvARoB8x//AdY8ADv/AdY8ADv/AdY8AAFCAU0BPgcAAT4DAAEoAwABeAMAAR4DAAEB
+        AQABAQUAAeABARYAA///AOIACw==
 </value>
-  </data>
-  <data name="$this.TrayLargeIcon" type="System.Boolean, mscorlib, Version=1.0.5000.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>False</value>
-  </data>
-  <data name="$this.Locked" type="System.Boolean, mscorlib, Version=1.0.5000.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>False</value>
-  </data>
-  <data name="$this.SnapToGrid" type="System.Boolean, mscorlib, Version=1.0.5000.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </data>
-  <data name="$this.DrawGrid" type="System.Boolean, mscorlib, Version=1.0.5000.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </data>
-  <data name="$this.TrayHeight" type="System.Int32, mscorlib, Version=1.0.5000.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>80</value>
-  </data>
-  <data name="$this.Language" type="System.Globalization.CultureInfo, mscorlib, Version=1.0.5000.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>(Default)</value>
-  </data>
-  <data name="$this.Localizable" type="System.Boolean, mscorlib, Version=1.0.5000.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>False</value>
-  </data>
-  <data name="$this.DefaultModifiers" type="System.CodeDom.MemberAttributes, System, Version=1.0.5000.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>Private</value>
-  </data>
-  <data name="$this.Name">
-    <value>uc_plot_add_edit</value>
-  </data>
-  <data name="$this.GridSize" type="System.Drawing.Size, System.Drawing, Version=1.0.5000.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>8, 8</value>
   </data>
 </root>

--- a/src/uc_plot_input.resx
+++ b/src/uc_plot_input.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="btnboxMDBFiadbInputFile.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="btnFilterByFileBrowse.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         Qk32AAAAAAAAAHYAAAAoAAAAEAAAABAAAAABAAQAAAAAAAAAAADEDgAAxA4AABAAAAAQAAAAAAAA/wAA
         gP8AgAD/AICA/4AAAP+AAID/gIAA/4CAgP/AwMD/AAD//wD/AP8A/////wAA//8A/////wD//////4iI
@@ -127,7 +127,7 @@
         iIiIiIiI
 </value>
   </data>
-  <data name="btnFilterByFileBrowse.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="btnboxMDBFiadbInputFile.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         Qk32AAAAAAAAAHYAAAAoAAAAEAAAABAAAAABAAQAAAAAAAAAAADEDgAAxA4AABAAAAAQAAAAAAAA/wAA
         gP8AgAD/AICA/4AAAP+AAID/gIAA/4CAgP/AwMD/AAD//wD/AP8A/////wAA//8A/////wD//////4iI


### PR DESCRIPTION
Delete conditions functionality added:
- supply a text file with cond.cn values to remove from a project, one per line, no punctuation or delimiters
- based on project root, looks in specific directories to remove records associated with biosum_cond_id/biosum_plot_id/standid/stand_id
- compacts databases after deleting

Empty fvs_cutlist generated and added to databases that are expected to have them. Only seems to occur in bad stands associated with year0 issue. 

Pre-processing audit ignores year=0 records in fvs_treelist.