### PR TITLE
Issue #160

### DIFF
--- a/src/Queries.cs
+++ b/src/Queries.cs
@@ -3066,403 +3066,724 @@ namespace FIA_Biosum_Manager
                                "f.drybiom=o.DRYBIOM_CALC," + 
                                "f.voltsgrs=o.VOLTSGRS_CALC" ;
                 }
-
-               
-                
-
-
-                
             }
-
 
             public class FVSInput
             {
-                FVSInput()
-                {
-                }
+		        FVSInput()
+		        {
+		        }
 
-                //All the queries necessary to create the FVSIn.accdb FVS_StandInit table using intermediate tables
-                public class StandInit
-                {
-                    StandInit()
-                    {
-                    }
+		        //All the queries necessary to create the FVSIn.accdb FVS_StandInit table using intermediate tables
+		        public class StandInit
+		        {
+		            StandInit()
+		            {
+		            }
 
-                    public static string BulkImportStandDataFromBioSumMaster(string strVariant, string strDestTable,
-                        string strCondTableName, string strPlotTableName)
-                    {
-                        string strInsertIntoStandInit =
-                            "INSERT INTO " + strDestTable +
-                            " (Stand_ID, Variant, Inv_Year, Latitude, Longitude, Location, PV_Code, " +
-                            "Age, Aspect, Slope, ElevFt, Basal_Area_Factor, Inv_Plot_Size, Brk_DBH, " +
-                            "Num_Plots, NonStk_Plots, Sam_Wt, Stk_Pcnt, DG_Trans, DG_Measure, " +
-                            "HTG_Trans, HTG_Measure, Mort_Measure, State, County) ";
-                        string strBioSumWorkTableSelectStmt =
-                            "SELECT c.biosum_cond_id, p.fvs_variant, p.measyear, p.lat, p.lon, IIF(c.adforcd is null, 0, c.adforcd), " +
-                            "c.habtypcd1, c.stdage, c.aspect, c.slope, p.elev, 0, 1, 999, 1, 0, 1,  " +
-                            "iif(c.landclcd is null, 0, c.landclcd), 1, 10, 1, 5, 5, p.statecd, p.countycd ";
-                        string strFromTableExpr =
-                            "FROM " + strCondTableName + " c INNER JOIN " + strPlotTableName +
-                            " p ON c.biosum_plot_id = p.biosum_plot_id ";
-                        string strFilters = "WHERE c.landclcd = 1 AND ucase(trim(p.fvs_variant)) = \'" +
-                                            strVariant.Trim().ToUpper() + "\'";
+		            public static string CreateDWMFuelbedTypCdToFVSConversionTable()
+		            {
+		                return "CREATE TABLE Ref_DWM_Fuelbed_Type_Codes (dwm_fuelbed_typcd TEXT(3), fuel_model LONG);";
+		            }
 
-                        return strInsertIntoStandInit + strBioSumWorkTableSelectStmt + strFromTableExpr +
-                               strFilters;
-                    }
+		            public static string BulkImportStandDataFromBioSumMaster(string strVariant, string strDestTable,
+		                string strCondTableName, string strPlotTableName)
+		            {
+		                string strInsertIntoStandInit =
+		                    "INSERT INTO " + strDestTable +
+		                    " (Stand_ID, Variant, Inv_Year, Latitude, Longitude, Location, PV_Code, " +
+		                    "Age, Aspect, Slope, ElevFt, Basal_Area_Factor, Inv_Plot_Size, Brk_DBH, " +
+		                    "Num_Plots, NonStk_Plots, Sam_Wt, Stk_Pcnt, DG_Trans, DG_Measure, " +
+		                    "HTG_Trans, HTG_Measure, Mort_Measure, Forest_Type, State, County) ";
+		                string strBioSumWorkTableSelectStmt =
+		                    "SELECT c.biosum_cond_id, p.fvs_variant, p.measyear, p.lat, p.lon, " +
+		                    "ref.FVSLocCode, c.habtypcd1, c.stdage, c.aspect, c.slope, p.elev, 0, 1, 999, 1, 0, 1,  " +
+		                    "iif(c.landclcd is null, 0, c.landclcd), 1, 10, 1, 5, 5, c.fortypcd, p.statecd, p.countycd ";
+		                string strFromTableExpr =
+		                    String.Format(
+		                        "FROM ({0} c INNER JOIN {1} p ON c.biosum_plot_id = p.biosum_plot_id) LEFT JOIN {2} ref " +
+		                        "ON p.statecd=ref.statecd AND p.countycd=ref.countycd AND p.plot=ref.plot ",
+		                        strCondTableName, strPlotTableName, Tables.Reference.DefaultFiadbFVSVariantTableName);
+		                string strFilters = "WHERE c.landclcd = 1 AND ucase(trim(p.fvs_variant)) = \'" +
+		                                    strVariant.Trim().ToUpper() + "\'";
+		                return strInsertIntoStandInit + strBioSumWorkTableSelectStmt + strFromTableExpr +
+		                       strFilters;
+		            }
 
-                    public static string CreateSiteIndexDataset(string strVariant,
-                        string strCondTableName, string strPlotTableName)
-                    {
-                        string strSQL = "SELECT p.biosum_plot_id, c.biosum_cond_id, p.statecd ," +
-                                        "p.countycd, p.plot, p.fvs_variant, p.measyear," +
-                                        "c.adforcd,p.elev,c.condid, c.habtypcd1," +
-                                        "c.stdage,c.slope,c.aspect,c.ground_land_class_pnw," +
-                                        "c.sisp,p.lat,p.lon,p.idb_plot_id,c.adforcd,c.habtypcd1, " +
-                                        "p.elev,c.landclcd,c.ba_ft2_ac,c.habtypcd1 " +
-                                        "FROM " + strCondTableName + " c," +
-                                        strPlotTableName + " p " +
-                                        "WHERE p.biosum_plot_id = c.biosum_plot_id AND " +
-                                        "c.landclcd=1 AND " +
-                                        "ucase(trim(p.fvs_variant)) = '" + strVariant.Trim().ToUpper() + "';";
-                        return strSQL;
-                    }
+		            public static string UpdateFuelModel(string strDestTable, string strCondTableName)
+		            {
+		                return String.Format(
+		                    "UPDATE ({0} fvs INNER JOIN {1} c ON fvs.Stand_ID=c.biosum_cond_id) " +
+		                    "LEFT JOIN {2} ref ON c.dwm_fuelbed_typcd=ref.dwm_fuelbed_typcd " +
+		                    "SET fvs.Fuel_Model=IIF(c.dwm_fuelbed_typcd IS NULL, NULL, ref.Fuel_Model);",
+		                    strDestTable, strCondTableName, "Ref_DWM_Fuelbed_Type_Codes");
+		            }
 
-                    public static string TranslateWorkTableToStandInitTable(string strSourceTable, string strDestTable)
-                    {
-                        string strInsertIntoStandInit =
-                            "INSERT INTO " + strDestTable +
-                            " (Stand_ID, Variant, Inv_Year, " +
-                            "Latitude, Longitude, Region, Forest, District, Compartment, " +
-                            "Location, Ecoregion, PV_Code, PV_Ref_Code, Age, Aspect, Slope, " +
-                            "Elevation, ElevFt, Basal_Area_Factor, Inv_Plot_Size, Brk_DBH, " +
-                            "Num_Plots, NonStk_Plots, Sam_Wt, Stk_Pcnt, DG_Trans, DG_Measure, " +
-                            "HTG_Trans, HTG_Measure, Mort_Measure, Max_BA, Max_SDI, " +
-                            "Site_Species, Site_Index, Model_Type, Physio_Region, Forest_Type, " +
-                            "State, County, Fuel_Model, Fuel_0_25_H, Fuel_25_1_H, Fuel_1_3_H, " +
-                            "Fuel_3_6_H, Fuel_6_12_H, Fuel_12_20_H, Fuel_20_35_H, Fuel_35_50_H, " +
-                            "Fuel_gt_50_H, Fuel_0_25_S, Fuel_25_1_S, Fuel_1_3_S, Fuel_3_6_S, " +
-                            "Fuel_6_12_S, Fuel_12_20_S, Fuel_20_35_S, Fuel_35_50_S, Fuel_gt_50_S, " +
-                            "Fuel_Litter, Fuel_Duff, Photo_Ref, Photo_code) ";
-                        string strBioSumWorkTableSelectStmt =
-                            "SELECT Stand_ID, Variant, Inv_Year, " +
-                            "Latitude, Longitude, Region, Forest, District, Compartment, " +
-                            "Location, Ecoregion, PV_Code, PV_Ref_Code, Age, Aspect, Slope, " +
-                            "Elevation, ElevFt, Basal_Area_Factor, Inv_Plot_Size, Brk_DBH, " +
-                            "Num_Plots, NonStk_Plots, Sam_Wt, Stk_Pcnt, DG_Trans, DG_Measure, " +
-                            "HTG_Trans, HTG_Measure, Mort_Measure, Max_BA, Max_SDI, " +
-                            "Site_Species, Site_Index, Model_Type, Physio_Region, Forest_Type, " +
-                            "State, County, Fuel_Model, Fuel_0_25_H, Fuel_25_1_H, Fuel_1_3_H, " +
-                            "Fuel_3_6_H, Fuel_6_12_H, Fuel_12_20_H, Fuel_20_35_H, Fuel_35_50_H, " +
-                            "Fuel_gt_50_H, Fuel_0_25_S, Fuel_25_1_S, Fuel_1_3_S, Fuel_3_6_S, " +
-                            "Fuel_6_12_S, Fuel_12_20_S, Fuel_20_35_S, Fuel_35_50_S, Fuel_gt_50_S, " +
-                            "Fuel_Litter, Fuel_Duff, Photo_Ref, Photo_code ";
-                        string strFromTableExpr = "FROM " + strSourceTable + ";";
-                        return strInsertIntoStandInit + strBioSumWorkTableSelectStmt + strFromTableExpr;
-                    }
+		            /// <summary>
+		            /// Calculate biomass contribution to condition per CWD piece so that they can be summed
+		            /// ScalingConstants * SpeciesBulkDensity * SpeciesDecayRatio * PieceTransectDiameter^2 / TotalTransectLengthForCondition
+		            /// </summary>
+		            /// <param name="strCoarseWoodyDebrisTable"></param>
+		            /// <param name="strCondTable"></param>
+		            /// <param name="strRefSpecies"></param>
+		            /// <param name="strTransectSegmentTable"></param>
+		            /// <returns></returns>
+		            public static string[] CalculateCoarseWoodyDebrisBiomassTonsPerAcre(string strCoarseWoodyDebrisTable,
+		                string strCondTable, string strRefSpecies, string strTransectSegmentTable, string strMinCwdTransectLengthTotal)
+		            {
+		                string[] strCwdSqlStmts = new string[11];
+		                int idx = 0;
 
-                    public static string InsertSiteIndexSpeciesRow(string strStandID, string strSiteSpecies,
-                        string strSiteIndex)
-                    {
-                        return String.Format(
-                            "UPDATE FVS_StandInit_WorkTable SET Site_Species={1}, Site_Index={2} WHERE STAND_ID={0}; ",
-                            strStandID, strSiteSpecies, strSiteIndex);
-                    }
+		                //Sum horizontal lengths for transects
+		                strCwdSqlStmts[idx++] = String.Format(
+		                    "SELECT biosum_cond_id, SUM(horiz_length) as CWDTotalLength " +
+		                    "INTO CWDTotalLengthWorkTable " +
+		                    "FROM {0} " +
+		                    "GROUP BY biosum_cond_id;", strTransectSegmentTable);
 
-                    public static string DeleteWorkTable()
-                    {
-                        return "DROP TABLE FVS_StandInit_WorkTable;";
-                    }
-                }
+		                //Create worktable for calculation of cwd piece biomass
+		                strCwdSqlStmts[idx++] = String.Format("SELECT cwd.biosum_cond_id, " +
+		                                                      "cwd.spcd, " +
+		                                                      "cwd.transdia, " +
+		                                                      "cwd.inclination, " +
+		                                                      "cwd.decaycd, " +
+		                                                      "CDbl(0) as BulkDensity, " +
+		                                                      "CDbl(0) as DecayRatio, " +
+		                                                      "tl.CWDTotalLength, " +
+		                                                      "CDbl(0) as Biomass, " +
+		                                                      //from NRS-22 Eqn 3.27
+		                                                      //.1865972082080956863 = (1.0/2000.0)*(43560.0/144.0)*(3.141592654^2/8.0)
+		                                                      "0.186597208 as ScalingConstants " +
+		                                                      "INTO CwdPieceWorkTable " +
+		                                                      "FROM {0} cwd " +
+		                                                      "INNER JOIN CWDTotalLengthWorkTable tl " +
+		                                                      "ON cwd.biosum_cond_id=tl.biosum_cond_id;",
+		                    strCoarseWoodyDebrisTable);
 
-                //All the queries necessary to create the FVSIn.accdb FVS_TreeInit table using intermediate tables
-                public class TreeInit
-                {
-                    TreeInit()
-                    {
-                    }
+		                //Set BulkDensity And DecayRatios for each piece for easy multiplication across row
+		                strCwdSqlStmts[idx++] = String.Format("UPDATE CwdPieceWorkTable cwd " +
+		                                                      "INNER JOIN {0} spc ON cwd.spcd=spc.spcd " +
+		                                                      "SET cwd.BulkDensity=spc.CWD_Bulk_Density," +
+		                                                      "cwd.DecayRatio=IIF(cwd.decaycd=1, spc.CWD_Decay_Ratio1, " +
+		                                                      "IIF(cwd.decaycd=2, spc.CWD_Decay_Ratio2, " +
+		                                                      "IIF(cwd.decaycd=3, spc.CWD_Decay_Ratio3, " +
+		                                                      "IIF(cwd.decaycd=4, spc.CWD_Decay_Ratio4, " +
+		                                                      "IIF(cwd.decaycd=5, spc.CWD_Decay_Ratio5, 0)))));",
+		                    strRefSpecies);
 
-                    public static string BulkImportTreeDataFromBioSumMaster(string strVariant, string strDestTable,
-                        string strCondTableName, string strPlotTableName, string strTreeTableName)
-                    {
-                        string strInsertIntoTreeInit =
-                            "INSERT INTO " + strDestTable +
-                            " (Stand_ID, Tree_ID, Tree_Count, History, Species, " +
-                            "DBH, DG, Htcd, Ht, HtTopK, CrRatio, " +
-                            "Damage1, Severity1, Damage2, Severity2, Damage3, Severity3, " +
-                            "Prescription, Slope, Aspect, PV_Code, TreeValue, cullbf, mist_cl_cd, " +
-                            "fvs_dmg_ag1, fvs_dmg_sv1, fvs_dmg_ag2, fvs_dmg_sv2, fvs_dmg_ag3, fvs_dmg_sv3, TreeCN)  ";
-                        string strBioSumWorkTableSelectStmt =
-                            "SELECT c.biosum_cond_id, VAL(t.fvs_tree_id) as Tree_ID, t.tpacurr, iif(iif(t.statuscd is null, 0, t.statuscd)=1, 1, 9) as History, t.spcd, " +
-                            "t.dia, t.inc10yr, t.htcd, iif(t.ht is null,0,t.ht), iif(t.actualht is null,0,t.actualht), t.cr, " +
-                            "0 as Damage1, 0 as Severity1, 0 as Damage2, 0 as Severity2, 0 as Damage3, 0 as Severity3, " +
-                            "0 as Prescription, c.slope, c.aspect, c.habtypcd1, 3 as TreeValue, t.cullbf, t.mist_cl_cd, " +
-                            "fvs_dmg_ag1, fvs_dmg_sv1, fvs_dmg_ag2, fvs_dmg_sv2, fvs_dmg_ag3, fvs_dmg_sv3, t.cn ";
-                        string strFromTableExpr = "FROM " +
-                                                  strCondTableName + " c, " + strPlotTableName + " p, " +
-                                                  strTreeTableName + " t ";
-                        string strFilters =
-                            "WHERE t.biosum_cond_id=c.biosum_cond_id AND p.biosum_plot_id=c.biosum_plot_id " +
-                            "AND t.dia > 0 AND c.landclcd=1 " +
-                            "AND ucase(trim(p.fvs_variant)) = \'" + strVariant.Trim().ToUpper() + "\'";
-                        string strSQL = strInsertIntoTreeInit + strBioSumWorkTableSelectStmt + strFromTableExpr +
-                                        strFilters;
-                        return strSQL;
-                    }
-
-                    public static string CreateSpcdConversionTable(string strCondTableName, string strPlotTableName,
-                        string strTreeTableName, string strTreeSpeciesTableName)
-                    {
-                        //Updating FIA Species Codes to FVS Species Codes
-                        //Build the temporary species code conversion table
-                        string strSelectIntoTempConversionTable =
-                            "SELECT DISTINCT p.FVS_VARIANT AS PLOT_FVS_VARIANT, ts.FVS_VARIANT AS TREE_SPECIES_FVS_VARIANT, t.SPCD AS FIA_SPCD, ts.FVS_INPUT_SPCD INTO SPCD_CHANGE_WORK_TABLE ";
-                        string strSpcdSources =
-                            "FROM ((" + strCondTableName + " AS c INNER JOIN " + strPlotTableName +
-                            " AS p ON c.biosum_plot_id = p.biosum_plot_id) INNER JOIN " + strTreeTableName +
-                            " AS t ON c.BIOSUM_COND_ID = t.biosum_cond_id) LEFT JOIN " + strTreeSpeciesTableName +
-                            " AS ts ON t.SPCD = ts.SPCD ";
-                        string strSpcdConversionFilters =
-                            "WHERE ts.FVS_VARIANT = p.FVS_VARIANT AND ts.FVS_INPUT_SPCD Is Not Null And ts.FVS_INPUT_SPCD <> t.SPCD;";
-                        string strSQL = strSelectIntoTempConversionTable + strSpcdSources + strSpcdConversionFilters;
-                        return strSQL;
-                    }
+		                //TODO: null spcd needs bulkdensity and decayratio
+		                strCwdSqlStmts[idx++] = String.Format(
+		                    "UPDATE CwdPieceWorkTable cwd, (SELECT * FROM {0} WHERE spcd=998) spc " +
+		                    "SET cwd.BulkDensity=spc.CWD_Bulk_Density," +
+		                    "cwd.DecayRatio=IIF(cwd.decaycd=1, spc.CWD_Decay_Ratio1, " +
+		                    "IIF(cwd.decaycd=2, spc.CWD_Decay_Ratio2, " +
+		                    "IIF(cwd.decaycd=3, spc.CWD_Decay_Ratio3, " +
+		                    "IIF(cwd.decaycd=4, spc.CWD_Decay_Ratio4, " +
+		                    "IIF(cwd.decaycd=5, spc.CWD_Decay_Ratio5, 0))))) " +
+		                    "WHERE cwd.spcd IS NULL;",
+		                    strRefSpecies);
 
 
-                    public static string UpdateFVSSpeciesCodeColumn(string strVariant, string strFVSTreeInitWorkTable)
-                    {
-                        string strSQL = "UPDATE " + strFVSTreeInitWorkTable +
-                                        " AS fvstree INNER JOIN SPCD_CHANGE_WORK_TABLE AS spcdchange ON VAL(fvstree.SPECIES) = spcdchange.FIA_SPCD " +
-                                        "SET fvstree.SPECIES = CSTR(spcdchange.FVS_INPUT_SPCD) " +
-                                        "WHERE TRIM(spcdchange.PLOT_FVS_VARIANT)=\'" + strVariant.Trim().ToUpper() +
-                                        "\'; ";
-                        return strSQL;
-                    }
-
-                    public static string DeleteCrRatiosForDeadTrees(string strDestTable)
-                    {
-                        return "UPDATE " + strDestTable + " SET CrRatio=null WHERE History=9;";
-                    }
-
-                    public static string RoundCrRatioToSingleDigitCodes(string strDestTable)
-                    {
-                        /*This is a test to compare predispose and fvsin CrRatio when you round up*/
-                        string strSQL = "UPDATE " + strDestTable + " SET " +
-                                        "CrRatio=iif(crratio is null, null, iif(len(trim(cstr(crratio)))=0, 0, " +
-                                        "iif(0 <= crratio AND crratio <= 10, 1, " +
-                                        "iif(crratio <= 20, 2, " +
-                                        "iif(crratio <= 30, 3, " +
-                                        "iif(crratio <= 40, 4, " +
-                                        "iif(crratio <= 50, 5, " +
-                                        "iif(crratio <= 60, 6, " +
-                                        "iif(crratio <= 70, 7, " +
-                                        "iif(crratio <= 80, 8, " +
-                                        "iif(crratio <= 100, 9, null)))))))))));";
-                        return strSQL;
-                    }
-
-                    public static string DeleteHtAndHtTopKForNonMeasuredHeights(string strDestTable)
-                    {
-                        return "UPDATE " + strDestTable + " SET Ht=0, HtTopK=0 WHERE Htcd NOT IN (1,2,3);";
-                    }
-
-                    public static string SetBrokenTopFlag(string strDestTable)
-                    {
-                        return "UPDATE " + strDestTable +
-                               " SET hasBrokenTop = -1 " + //-1 is true in access
-                               "WHERE HtTopK < Ht AND 0 < HtTopK;";
-                    }
+		                //Calculate the CWD piece's biomass contribution to the condition
+		                //The last step is to group these by biosum_cond_id and sum them
+		                strCwdSqlStmts[idx++] = "UPDATE CwdPieceWorkTable cwd " +
+		                                        "SET cwd.Biomass=cwd.ScalingConstants*cwd.BulkDensity*cwd.DecayRatio*cwd.transdia^2/cwd.CWDTotalLength;";
 
 
-                    public static string SetHtTopKToZeroIfGteHt(string strDestTable)
-                    {
-                        return "UPDATE " + strDestTable + " SET HtTopK=0 WHERE Ht <= HtTopK";
-                    }
+                        //Update CWD piece's biomass: scale by cosine_inclination or 1 if inclination is null 
+                        //Piece inclination is measured in degrees from 0 to 90. Convert to radians for Access cosine function
+		                strCwdSqlStmts[idx++] = "UPDATE CwdPieceWorkTable cwd " +
+		                                        "SET cwd.Biomass=cwd.Biomass/COS(cwd.inclination * 3.141592654/180)" +
+		                                        "WHERE cwd.inclination IS NOT NULL;";
+
+		                //Sum by size and decay bins to match FVS_StandInit columns
+		                strCwdSqlStmts[idx++] = "SELECT cwd.biosum_cond_id, " +
+		                                        "SUM(IIF((cwd.transdia >= 3 AND cwd.transdia < 6) AND (cwd.decaycd IN (1,2,3)), " +
+		                                        "cwd.Biomass, 0)) as fuel_3_6_H, " +
+		                                        "SUM(IIF((cwd.transdia >= 6 AND cwd.transdia < 12) AND (cwd.decaycd IN (1,2,3)), " +
+		                                        "cwd.Biomass, 0)) as fuel_6_12_H, " +
+		                                        "SUM(IIF((cwd.transdia >= 12 AND cwd.transdia < 20) AND (cwd.decaycd IN (1,2,3)), " +
+		                                        "cwd.Biomass, 0)) as fuel_12_20_H, " +
+		                                        "SUM(IIF((cwd.transdia >= 20 AND cwd.transdia < 35) AND (cwd.decaycd IN (1,2,3)), " +
+		                                        "cwd.Biomass, 0)) as fuel_20_35_H, " +
+		                                        "SUM(IIF((cwd.transdia >= 35 AND cwd.transdia < 50) AND (cwd.decaycd IN (1,2,3)), " +
+		                                        "cwd.Biomass, 0)) as fuel_35_50_H, " +
+		                                        "SUM(IIF((cwd.transdia >= 50 AND cwd.transdia < 999) AND (cwd.decaycd IN (1,2,3)), " +
+		                                        "cwd.Biomass, 0)) as fuel_gt_50_H, " +
+		                                        "SUM(IIF((cwd.transdia >= 3 AND cwd.transdia < 6) AND (cwd.decaycd IN (4,5)), " +
+		                                        "cwd.Biomass, 0)) as fuel_3_6_S, " +
+		                                        "SUM(IIF((cwd.transdia >= 6 AND cwd.transdia < 12) AND (cwd.decaycd IN (4,5)), " +
+		                                        "cwd.Biomass, 0)) as fuel_6_12_S, " +
+		                                        "SUM(IIF((cwd.transdia >= 12 AND cwd.transdia < 20) AND (cwd.decaycd IN (4,5)), " +
+		                                        "cwd.Biomass, 0)) as fuel_12_20_S, " +
+		                                        "SUM(IIF((cwd.transdia >= 20 AND cwd.transdia < 35) AND (cwd.decaycd IN (4,5)), " +
+		                                        "cwd.Biomass, 0)) as fuel_20_35_S, " +
+		                                        "SUM(IIF((cwd.transdia >= 35 AND cwd.transdia < 50) AND (cwd.decaycd IN (4,5)), " +
+		                                        "cwd.Biomass, 0)) as fuel_35_50_S, " +
+		                                        "SUM(IIF((cwd.transdia >= 50 AND cwd.transdia < 999) AND (cwd.decaycd IN (4,5)), " +
+		                                        "cwd.Biomass, 0)) as fuel_gt_50_S " +
+		                                        "INTO DWM_CWD_Aggregates_WorkTable " +
+		                                        "FROM CwdPieceWorkTable cwd " +
+		                                        "GROUP BY cwd.biosum_cond_id;";
+
+		                //Update CWD columns in FVS_StandInit
+		                strCwdSqlStmts[idx++] = "UPDATE FVS_StandInit_WorkTable fvs " +
+		                                        "INNER JOIN DWM_CWD_Aggregates_WorkTable cwd ON fvs.Stand_ID=cwd.biosum_cond_id " +
+		                                        "SET fvs.fuel_3_6_H=cwd.fuel_3_6_H, " +
+		                                        "fvs.fuel_6_12_H=cwd.fuel_6_12_H, " +
+		                                        "fvs.fuel_12_20_H=cwd.fuel_12_20_H, " +
+		                                        "fvs.fuel_20_35_H=cwd.fuel_20_35_H, " +
+		                                        "fvs.fuel_35_50_H=cwd.fuel_35_50_H, " +
+		                                        "fvs.fuel_gt_50_H=cwd.fuel_gt_50_H, " +
+		                                        "fvs.fuel_3_6_S=cwd.fuel_3_6_S, " +
+		                                        "fvs.fuel_6_12_S=cwd.fuel_6_12_S, " +
+		                                        "fvs.fuel_12_20_S=cwd.fuel_12_20_S, " +
+		                                        "fvs.fuel_20_35_S=cwd.fuel_20_35_S, " +
+		                                        "fvs.fuel_35_50_S=cwd.fuel_35_50_S, " +
+		                                        "fvs.fuel_gt_50_S=cwd.fuel_gt_50_S;";
+
+		                //Write them to fvs_standinit column
+		                strCwdSqlStmts[idx++] = "UPDATE FVS_StandInit_WorkTable fvs " +
+		                                        "INNER JOIN CWDTotalLengthWorkTable t ON fvs.stand_id=t.biosum_cond_id " +
+		                                        "SET fvs.cwdtotallength=t.CWDTotalLength;";
+		                
+		                //Nullify CWD where total horizontal length is less than the minimum
+		                strCwdSqlStmts[idx++] = String.Format("UPDATE FVS_StandInit_WorkTable fvs " +
+		                                        "INNER JOIN CWDTotalLengthWorkTable t ON fvs.stand_id=t.biosum_cond_id " +
+		                                        "SET fvs.fuel_3_6_H=NULL, " +
+		                                        "fvs.fuel_6_12_H=NULL, " +
+		                                        "fvs.fuel_12_20_H=NULL, " +
+		                                        "fvs.fuel_20_35_H=NULL, " +
+		                                        "fvs.fuel_35_50_H=NULL, " +
+		                                        "fvs.fuel_gt_50_H=NULL, " +
+		                                        "fvs.fuel_3_6_S=NULL, " +
+		                                        "fvs.fuel_6_12_S=NULL, " +
+		                                        "fvs.fuel_12_20_S=NULL, " +
+		                                        "fvs.fuel_20_35_S=NULL, " +
+		                                        "fvs.fuel_35_50_S=NULL, " +
+		                                        "fvs.fuel_gt_50_S=NULL " + 
+		                                        "WHERE fvs.CwdTotalLength < {0};", strMinCwdTransectLengthTotal);
+
+		                //Set cwd fuels to 0 if TS.horiz_length is non-null and positive
+		                //FVS interprets 0s as 0 tons/acre, but null lets it insert default values for the variant.
+                        strCwdSqlStmts[idx++] = String.Format("UPDATE FVS_StandInit_WorkTable " +
+                                                              "SET Fuel_3_6_H=IIF(Fuel_3_6_H is null, 0, Fuel_3_6_H), " +
+                                                              "Fuel_6_12_H=IIF(Fuel_6_12_H is null, 0, Fuel_6_12_H), " +
+                                                              "Fuel_12_20_H=IIF(Fuel_12_20_H is null, 0, Fuel_12_20_H), " +
+                                                              "Fuel_20_35_H=IIF(Fuel_20_35_H is null, 0, Fuel_20_35_H), " +
+                                                              "Fuel_35_50_H=IIF(Fuel_35_50_H is null, 0, Fuel_35_50_H), " +
+                                                              "Fuel_gt_50_H=IIF(Fuel_gt_50_H is null, 0, Fuel_gt_50_H), " +
+                                                              "Fuel_3_6_S=IIF(Fuel_3_6_S is null, 0, Fuel_3_6_S), " +
+                                                              "Fuel_6_12_S=IIF(Fuel_6_12_S is null, 0, Fuel_6_12_S), " +
+                                                              "Fuel_12_20_S=IIF(Fuel_12_20_S is null, 0, Fuel_12_20_S), " +
+                                                              "Fuel_20_35_S=IIF(Fuel_20_35_S is null, 0, Fuel_20_35_S), " +
+                                                              "Fuel_35_50_S=IIF(Fuel_35_50_S is null, 0, Fuel_35_50_S), " +
+                                                              "Fuel_gt_50_S=IIF(Fuel_gt_50_S is null, 0, Fuel_gt_50_S) " +
+                                                              "WHERE CWDTotalLength > 0;");
+
+		                return strCwdSqlStmts;
+		            }
+
+                    /// <summary>
+                    /// Calculate biomass for FWD columns in FVS_StandInit_WorkTable. 
+                    /// </summary>
+                    /// <param name="strDwmFineWoodyDebrisTable"></param>
+                    /// <param name="strCondTable"></param>
+                    /// <param name="strRefForestTypeTable"></param>
+                    /// <param name="strRefForestTypeGroupTable"></param>
+                    /// <param name="strMinSmallFwdTransectLengthTotal"></param>
+                    /// <param name="strMinLargeFwdTransectLengthTotal"></param>
+                    /// <returns></returns>
+		            public static string[] CalculateFineWoodyDebrisBiomassTonsPerAcre(string strDwmFineWoodyDebrisTable,
+		                string strCondTable, string strMinSmallFwdTransectLengthTotal, string strMinLargeFwdTransectLengthTotal)
+		            {
+		                string[] strFwdSqlStmts = new string[7];
+		                int idx = 0;
+
+                        //Gather variables for NRS-22 FWD equation into temporary table
+		                strFwdSqlStmts[idx++] = String.Format(
+		                    "SELECT fwd.biosum_cond_id, first(fwd.rsnctcd) as rsncntcd, " +
+		                    "sum(fwd.smallct) as smallTotal, first(fwd.small_tl_cond) as smallTL, " +
+		                    "sum(fwd.mediumct) as mediumTotal, first(fwd.medium_tl_cond) as mediumTL, " +
+		                    "sum(fwd.largect) as largeTotal, first(fwd.large_tl_cond) as largeTL, " +
+		                    "first(rftg.fwd_decay_ratio) as decayRatio, first(rftg.fwd_density) as bulkDensity, " +
+		                    "first(rftg.fwd_small_qmd) as smallQMD,  " +
+		                    "first(rftg.fwd_medium_qmd) as mediumQMD,  " +
+		                    "first(rftg.fwd_large_qmd) as largeQMD, " +
+		                    "first(small_tl_cond) as SmallMediumTotalLength, " +
+		                    "first(large_tl_cond) as LargeTotalLength, " +
+		                    "0.186597208 as ScalingConstants " +
+		                    "INTO DWM_FWD_Aggregates_WorkTable " +
+		                    "FROM (({0} fwd INNER JOIN {1} c ON fwd.biosum_cond_id = c.biosum_cond_id) " +
+		                    "INNER JOIN REF_FOREST_TYPE rft ON c.fortypcd = rft.`VALUE`) " +
+		                    "INNER JOIN REF_FOREST_TYPE_GROUP rftg ON rft.TYPGRPCD = rftg.`VALUE` " +
+		                    "WHERE fwd.rsnctcd < 2 OR fwd.rsnctcd IS NULL " +
+		                    "GROUP BY fwd.biosum_cond_id;", strDwmFineWoodyDebrisTable, strCondTable);
 
 
-                    public static string SetInferredSeedlingDbh(string strDestTable)
-                    {
-                        return "UPDATE " + strDestTable +
-                               " SET Dbh=0.1 WHERE Tree_Count > 25 AND Dbh <= 0 AND History=1;";
-                    }
+                        //Creates a table for scaling FWD TLs because the counts (small, medium, large) are filtered by RsnCtCd
+		                strFwdSqlStmts[idx++] = String.Format("SELECT fwd.biosum_cond_id, " +
+		                                                      "COUNT(iif(rsnctcd < 2 OR rsnctcd IS NULL, true, null)) as totalAcceptabelRsnCtCd, " +
+		                                                      "COUNT(*) as totalFWDRecords, " +
+		                                                      "CDbl(totalAcceptabelRsnCtCd)/totalFWDRecords as RsnCtCdScalingFactor " +
+		                                                      "INTO Dwm_Fwd_RsnCtCd_WorkTable " +
+		                                                      "FROM {0} fwd INNER JOIN FVS_StandInit_WorkTable fvs ON fwd.biosum_cond_id=fvs.stand_id " +
+		                                                      "GROUP BY fwd.biosum_cond_id", strDwmFineWoodyDebrisTable);
 
-                    public static string[] DamageCodes(string strDestTable)
-                    {
-                        string[] strDamageCodeUpdates = new string[15];
+                        //Multiply the FWD transect lengths for biomass calculations by the proportion of TLs with accepted RsnCtCds.
+                        //These RsnCtCd values are currently filtered out (2,3,4). Nulls are kept in.
+		                strFwdSqlStmts[idx++] = String.Format("UPDATE DWM_FWD_Aggregates_WorkTable fwd " +
+		                                                      "INNER JOIN Dwm_Fwd_RsnCtCd_WorkTable rsn " +
+		                                                      "ON fwd.biosum_cond_id=rsn.biosum_cond_id " +
+		                                                      "SET fwd.smallTL=fwd.smallTL*rsn.RsnCtCdScalingFactor, " +
+		                                                      "fwd.mediumTL=fwd.mediumTL*rsn.RsnCtCdScalingFactor, " +
+		                                                      "fwd.largeTL=fwd.largeTL*rsn.RsnCtCdScalingFactor, " +
+		                                                      "fwd.SmallMediumTotalLength=fwd.SmallMediumTotalLength*rsn.RsnCtCdScalingFactor, " +
+		                                                      "fwd.LargeTotalLength=fwd.LargeTotalLength*rsn.RsnCtCdScalingFactor;");
 
-                        //use precalculated damage codes if possible
-                        strDamageCodeUpdates[0] =
-                            "UPDATE " + strDestTable +
-                            " SET Damage1=fvs_dmg_ag1, Damage2=fvs_dmg_ag2, Damage3=fvs_dmg_ag3, Severity1=fvs_dmg_sv1, Severity2=fvs_dmg_sv2, Severity3=fvs_dmg_sv3 WHERE History=1 AND fvs_dmg_ag1 is not null;";
 
-                        //Cull board feet
-                        strDamageCodeUpdates[1] =
-                            "UPDATE " + strDestTable +
-                            " SET Damage1=25, Severity1=IIF(cullbf>=100, 99, cullbf) WHERE History=1 AND cullbf>0;";
+		                strFwdSqlStmts[idx++] = "UPDATE FVS_StandInit_WorkTable fvs " +
+		                                        "INNER JOIN DWM_FWD_Aggregates_WorkTable fwd " +
+		                                        "ON fvs.stand_id=fwd.biosum_cond_id " +
+		                                        "SET fvs.fuel_0_25_H=IIF(smallTL=0 OR smallTL IS NULL, NULL, " +
+		                                        "(fwd.ScalingConstants * (fwd.smallTotal * fwd.smallQMD^2) / fwd.smallTL) * fwd.bulkDensity * fwd.decayRatio), " +
+		                                        "fvs.fuel_25_1_H=IIF(mediumTL=0 OR mediumTL IS NULL, NULL, " +
+		                                        "(fwd.ScalingConstants * (fwd.mediumTotal * fwd.mediumQMD^2) / fwd.mediumTL) * fwd.bulkDensity * fwd.decayRatio), " +
+		                                        "fvs.fuel_1_3_H=IIF(largeTL=0 OR largeTL IS NULL, NULL, " +
+		                                        "(fwd.ScalingConstants * (fwd.largeTotal * fwd.largeQMD^2) / fwd.largeTL) * fwd.bulkDensity * fwd.decayRatio), " +
+		                                        "fvs.fuel_0_25_S=IIF(smallTL=0 OR smallTL IS NULL, NULL, 0), " +
+		                                        "fvs.fuel_25_1_S=IIF(mediumTL=0 OR mediumTL IS NULL, NULL, 0), " +
+		                                        "fvs.fuel_1_3_S=IIF(largeTL=0 OR largeTL IS NULL, NULL, 0), " +
+		                                        "fvs.SmallMediumTotalLength=fwd.SmallMediumTotalLength," +
+		                                        "fvs.LargeTotalLength=fwd.LargeTotalLength;";
 
-                        //FVS Mistletoe damage codes
-                        string strDamage1_Filter =
-                            "History=1 AND iif(mist_cl_cd is null,0,mist_cl_cd) <> 0 AND Damage1 = 0 AND fvs_dmg_ag1 is null;";
-                        string strDamage2_Filter =
-                            "History=1 AND iif(mist_cl_cd is null,0,mist_cl_cd) <> 0 AND Damage1 NOT IN (0, 30, 31, 32, 33, 34) AND fvs_dmg_ag1 is null;";
-                        strDamageCodeUpdates[2] =
-                            "UPDATE " + strDestTable +
-                            " SET Damage1=31, Severity1=mist_cl_cd WHERE Species=\'108\' AND " +
-                            strDamage1_Filter;
+		                // Set FWD columns to null if the scaling factor determined by all the DWM_Fine_Woody_Debris.RsnCtCd is 0.
+		                strFwdSqlStmts[idx++] = "UPDATE FVS_StandInit_WorkTable fvs " +
+		                                        "INNER JOIN Dwm_Fwd_RsnCtCd_WorkTable rsn " +
+		                                        "ON fvs.stand_id=rsn.biosum_cond_id " +
+		                                        "SET fvs.fuel_0_25_H=NULL, " +
+		                                        "fvs.fuel_25_1_H=NULL," +
+		                                        "fvs.fuel_1_3_H=NULL, " +
+		                                        "fvs.fuel_0_25_S=NULL, " +
+		                                        "fvs.fuel_25_1_S=NULL, " +
+		                                        "fvs.fuel_1_3_S=NULL, " +
+		                                        "fvs.SmallMediumTotalLength=NULL, " +
+		                                        "fvs.LargeTotalLength=NULL " +
+		                                        "WHERE rsn.RsnCtCdScalingFactor=0;";
 
-                        strDamageCodeUpdates[3] =
-                            "UPDATE " + strDestTable +
-                            " SET Damage2=31, Severity2=mist_cl_cd WHERE Species=\'108\' AND " +
-                            strDamage2_Filter;
+		                //Filter out FWD Small and Medium fuels where the minimum Small TL is larger
+		                strFwdSqlStmts[idx++] = String.Format("UPDATE FVS_StandInit_WorkTable fvs " +
+		                                                      "SET fvs.fuel_0_25_H=NULL, " +
+		                                                      "fvs.fuel_25_1_H=NULL, " +
+		                                                      "fvs.fuel_0_25_S=NULL, " +
+		                                                      "fvs.fuel_25_1_S=NULL " +
+		                                                      "WHERE fvs.SmallMediumTotalLength < {0} ",
+		                    strMinSmallFwdTransectLengthTotal);
 
-                        strDamageCodeUpdates[4] =
-                            "UPDATE " + strDestTable +
-                            " SET Damage1=32, Severity1=mist_cl_cd WHERE Species=\'073\' AND " +
-                            strDamage1_Filter;
+		                //Filter out FWD Large fuels where the minimum Large TL is larger
+		                strFwdSqlStmts[idx++] = String.Format("UPDATE FVS_StandInit_WorkTable fvs " +
+		                                                      "SET fvs.fuel_1_3_H=NULL, " +
+		                                                      "fvs.fuel_1_3_S=NULL " +
+		                                                      "WHERE fvs.LargeTotalLength < {0} ",
+		                    strMinLargeFwdTransectLengthTotal);
+		                return strFwdSqlStmts;
+		            }
 
-                        strDamageCodeUpdates[5] =
-                            "UPDATE " + strDestTable +
-                            " SET Damage2=32, Severity2=mist_cl_cd WHERE Species=\'073\' AND " +
-                            strDamage2_Filter;
+		            public static string CalculateDuffLitterBiomassTonsPerAcre(string strDwmDuffLitterTable, string strCondTable)
+		            {
+		                return String.Format(
+		                    "SELECT dl.biosum_cond_id, " +
+		                    "SUM(IIF(duffdep IS NOT NULL, 1, 0)) as DuffPitCount, " +
+		                    "SUM(IIF(littdep IS NOT NULL, 1, 0)) as LitterPitCount, " +
+		                    "(AVG(dl.duffdep)*first(rftg.duff_density)*1.815) as fvs_fuel_duff_tonsPerAcre, " +
+		                    "(AVG(dl.littdep)*first(rftg.litter_density)*1.815) as fvs_fuel_litter_tonsPerAcre " +
+		                    "INTO DWM_DuffLitter_Aggregates_WorkTable " +
+		                    "FROM ((({0} dl " +
+		                    "INNER JOIN {1} c ON dl.biosum_cond_id = c.biosum_cond_id) " +
+		                    "INNER JOIN REF_FOREST_TYPE rft ON c.fortypcd = rft.`VALUE`) " +
+		                    "INNER JOIN REF_FOREST_TYPE_GROUP rftg ON rft.TYPGRPCD = rftg.`VALUE`) " +
+		                    "INNER JOIN FVS_StandInit_WorkTable fvs on dl.biosum_cond_id=fvs.stand_ID " +
+		                    "GROUP BY dl.biosum_cond_id;", strDwmDuffLitterTable, strCondTable);
+		            }
 
-                        strDamageCodeUpdates[6] =
-                            "UPDATE " + strDestTable +
-                            " SET Damage1=33, Severity1=mist_cl_cd WHERE Species=\'202\' AND " +
-                            strDamage1_Filter;
+		            public static string UpdateFvsStandInitDuffLitterColumns()
+		            {
+		                return "UPDATE Fvs_StandInit_WorkTable fvs " +
+		                       "INNER JOIN DWM_DuffLitter_Aggregates_WorkTable dl ON fvs.stand_id=dl.biosum_cond_id  " +
+		                       "SET fvs.fuel_duff = dl.fvs_fuel_duff_tonsPerAcre, " +
+		                       "fvs.fuel_litter = dl.fvs_fuel_litter_tonsPerAcre," +
+		                       "fvs.DuffPitCount = dl.DuffPitCount," +
+		                       "fvs.LitterPitCount = dl.LitterPitCount;";
+		            }
 
-                        strDamageCodeUpdates[7] =
-                            "UPDATE " + strDestTable +
-                            " SET Damage2=33, Severity2=mist_cl_cd WHERE Species=\'202\' AND " +
-                            strDamage2_Filter;
+		            public static string RemoveDuffYears(string yearsFilter)
+		            {
+		                return "UPDATE Fvs_StandInit_WorkTable fvs " +
+		                       "SET fvs.fuel_duff = null," +
+		                       "fvs.DuffPitCount=null " +
+		                       "WHERE fvs.inv_year IN (" + yearsFilter + ")";
+		            }
 
-                        strDamageCodeUpdates[8] =
-                            "UPDATE " + strDestTable +
-                            " SET Damage1=34, Severity1=mist_cl_cd WHERE Species=\'122\' AND " +
-                            strDamage1_Filter;
+		            public static string RemoveLitterYears(string yearsFilter)
+		            {
+		                return "UPDATE Fvs_StandInit_WorkTable fvs " +
+		                       "SET fvs.fuel_litter=null," +
+		                       "fvs.LitterPitCount=null " +
+		                       "WHERE fvs.inv_year IN (" + yearsFilter + ")";
+		            }
 
-                        strDamageCodeUpdates[9] =
-                            "UPDATE " + strDestTable +
-                            " SET Damage2=34, Severity2=mist_cl_cd WHERE Species=\'122\' AND " +
-                            strDamage2_Filter;
+		            public static string CreateSiteIndexDataset(string strVariant,
+		                string strCondTableName, string strPlotTableName)
+		            {
+		                string strSQL = "SELECT p.biosum_plot_id, c.biosum_cond_id, p.statecd ," +
+		                                "p.countycd, p.plot, p.fvs_variant, p.measyear," +
+		                                "c.adforcd,p.elev,c.condid, c.habtypcd1," +
+		                                "c.stdage,c.slope,c.aspect,c.ground_land_class_pnw," +
+		                                "c.sisp,p.lat,p.lon,p.idb_plot_id,c.adforcd,c.habtypcd1, " +
+		                                "p.elev,c.landclcd,c.ba_ft2_ac,c.habtypcd1 " +
+		                                "FROM " + strCondTableName + " c," +
+		                                strPlotTableName + " p " +
+		                                "WHERE p.biosum_plot_id = c.biosum_plot_id AND " +
+		                                "c.landclcd=1 AND " +
+		                                "ucase(trim(p.fvs_variant)) = '" + strVariant.Trim().ToUpper() + "';";
+		                return strSQL;
+		            }
 
-                        //default mist_cl_cd damage code if fvs species don't match previous four cases
-                        strDamageCodeUpdates[10] =
-                            "UPDATE " + strDestTable +
-                            " SET Damage1=30, Severity1=mist_cl_cd WHERE Species NOT IN (\'202\',\'108\',\'122\',\'073\') AND " +
-                            strDamage1_Filter;
+		            public static string TranslateWorkTableToStandInitTable(string strSourceTable, string strDestTable)
+		            {
+		                string strInsertIntoStandInit =
+		                    "INSERT INTO " + strDestTable;
+		                string strBioSumWorkTableSelectStmt =
+		                    " SELECT Stand_ID, Variant, Inv_Year, " +
+		                    "Latitude, Longitude, Region, Forest, District, Compartment, " +
+		                    "Location, Ecoregion, PV_Code, PV_Ref_Code, Age, Aspect, Slope, " +
+		                    "Elevation, ElevFt, Basal_Area_Factor, Inv_Plot_Size, Brk_DBH, " +
+		                    "Num_Plots, NonStk_Plots, Sam_Wt, Stk_Pcnt, DG_Trans, DG_Measure, " +
+		                    "HTG_Trans, HTG_Measure, Mort_Measure, Max_BA, Max_SDI, " +
+		                    "Site_Species, Site_Index, Model_Type, Physio_Region, Forest_Type, " +
+		                    "State, County, Fuel_Model,[Fuel_0_25_H], [Fuel_25_1_H], [Fuel_1_3_H], " +
+		                    "[Fuel_3_6_H], [Fuel_6_12_H], [Fuel_12_20_H], Fuel_20_35_H, Fuel_35_50_H, " +
+		                    "Fuel_gt_50_H, Fuel_0_25_S, Fuel_25_1_S, Fuel_1_3_S, Fuel_3_6_S, " +
+		                    "Fuel_6_12_S, Fuel_12_20_S, Fuel_20_35_S, Fuel_35_50_S, Fuel_gt_50_S, " +
+		                    "Fuel_Litter, Fuel_Duff, SmallMediumTotalLength, " +
+		                    "LargeTotalLength, CWDTotalLength, DuffPitCount, LitterPitCount, " +
+		                    "Photo_Ref, Photo_code ";
+		                string strFromTableExpr = "FROM " + strSourceTable + ";";
+		                return strInsertIntoStandInit + strBioSumWorkTableSelectStmt + strFromTableExpr;
+		            }
 
-                        strDamageCodeUpdates[11] =
-                            "UPDATE " + strDestTable +
-                            " SET Damage2=30, Severity2=mist_cl_cd WHERE Species NOT IN (\'202\',\'108\',\'122\',\'073\') AND " +
-                            strDamage2_Filter;
+		            public static string InsertSiteIndexSpeciesRow(string strStandID, string strSiteSpecies,
+		                string strSiteIndex)
+		            {
+		                return String.Format(
+		                    "UPDATE FVS_StandInit_WorkTable SET Site_Species={1}, Site_Index={2} WHERE STAND_ID={0}; ",
+		                    strStandID, strSiteSpecies, strSiteIndex);
+		            }
 
-                        //broken top 96 added to least priority(?) damage column so fill it last
-                        strDamageCodeUpdates[12] =
-                            "UPDATE " + strDestTable +
-                            " SET Damage1=96 WHERE History=1 AND hasBrokenTop AND Damage1 = 0 AND fvs_dmg_ag1 is null;";
+		            public static string DeleteFvsStandInitWorkTable()
+		            {
+		                return "DROP TABLE FVS_StandInit_WorkTable;";
+		            }
 
-                        //0 means nothing was assigned. 96 means damage2 doesn't need to repeat damage1
-                        strDamageCodeUpdates[13] =
-                            "UPDATE " + strDestTable +
-                            " SET Damage2=96 WHERE History=1 AND hasBrokenTop AND Damage1 NOT IN (0,96) AND Damage2 = 0 AND fvs_dmg_ag1 IS Null;";
 
-                        strDamageCodeUpdates[14] =
-                            "UPDATE " + strDestTable +
-                            " SET Damage3=96 WHERE History=1 AND hasBrokenTop AND Damage1 NOT IN (0,96) AND Damage2 not in (0,96) and Damage3=0 AND fvs_dmg_ag1 IS Null;";
-                        /*END DAMAGE CODES*/
-                        return strDamageCodeUpdates;
-                    }
+		            public static string[] DeleteDwmWorkTables()
+		            {
+		                string[] strSQL = new string[6];
+		                int idx = 0;
+		                strSQL[idx++] = "DROP TABLE CWDTotalLengthWorkTable;";
+		                strSQL[idx++] = "DROP TABLE CwdPieceWorkTable;";
+		                strSQL[idx++] = "DROP TABLE DWM_CWD_Aggregates_WorkTable;";
+		                strSQL[idx++] = "DROP TABLE DWM_FWD_Aggregates_WorkTable;";
+		                strSQL[idx++] = "DROP TABLE DWM_DuffLitter_Aggregates_WorkTable;";
+		                strSQL[idx++] = "DROP TABLE Dwm_Fwd_RsnCtCd_WorkTable;";
+		                return strSQL;
+		            }
+		        }
 
-                    public static string[] TreeValueClass(string strDestTable)
-                    {
-                        /*Value Classes: 
+		        //All the queries necessary to create the FVSIn.accdb FVS_TreeInit table using intermediate tables
+		        public class TreeInit
+		        {
+		            TreeInit()
+		            {
+		            }
+
+		            public static string BulkImportTreeDataFromBioSumMaster(string strVariant, string strDestTable,
+		                string strCondTableName, string strPlotTableName, string strTreeTableName)
+		            {
+		                string strInsertIntoTreeInit =
+		                    "INSERT INTO " + strDestTable +
+		                    " (Stand_ID, Tree_ID, Tree_Count, History, Species, " +
+		                    "DBH, DG, Htcd, Ht, HtTopK, CrRatio, " +
+		                    "Damage1, Severity1, Damage2, Severity2, Damage3, Severity3, " +
+		                    "Prescription, Slope, Aspect, PV_Code, TreeValue, cullbf, mist_cl_cd, " +
+		                    "fvs_dmg_ag1, fvs_dmg_sv1, fvs_dmg_ag2, fvs_dmg_sv2, fvs_dmg_ag3, fvs_dmg_sv3, TreeCN)  ";
+		                string strBioSumWorkTableSelectStmt =
+		                    "SELECT c.biosum_cond_id, VAL(t.fvs_tree_id) as Tree_ID, t.tpacurr, iif(iif(t.statuscd is null, 0, t.statuscd)=1, 1, 9) as History, t.spcd, " +
+		                    "t.dia, t.inc10yr, t.htcd, iif(t.ht is null,0,t.ht), iif(t.actualht is null,0,t.actualht), t.cr, " +
+		                    "0 as Damage1, 0 as Severity1, 0 as Damage2, 0 as Severity2, 0 as Damage3, 0 as Severity3, " +
+		                    "0 as Prescription, c.slope, c.aspect, c.habtypcd1, 3 as TreeValue, t.cullbf, t.mist_cl_cd, " +
+		                    "fvs_dmg_ag1, fvs_dmg_sv1, fvs_dmg_ag2, fvs_dmg_sv2, fvs_dmg_ag3, fvs_dmg_sv3, t.cn ";
+		                string strFromTableExpr = "FROM " +
+		                                          strCondTableName + " c, " + strPlotTableName + " p, " +
+		                                          strTreeTableName + " t ";
+		                string strFilters =
+		                    "WHERE t.biosum_cond_id=c.biosum_cond_id AND p.biosum_plot_id=c.biosum_plot_id " +
+		                    "AND t.dia > 0 AND c.landclcd=1 " +
+		                    "AND ucase(trim(p.fvs_variant)) = \'" + strVariant.Trim().ToUpper() + "\'";
+		                string strSQL = strInsertIntoTreeInit + strBioSumWorkTableSelectStmt + strFromTableExpr +
+		                                strFilters;
+		                return strSQL;
+		            }
+
+		            public static string CreateSpcdConversionTable(string strCondTableName, string strPlotTableName,
+		                string strTreeTableName, string strTreeSpeciesTableName)
+		            {
+		                //Updating FIA Species Codes to FVS Species Codes
+		                //Build the temporary species code conversion table
+		                string strSelectIntoTempConversionTable =
+		                    "SELECT DISTINCT p.FVS_VARIANT AS PLOT_FVS_VARIANT, ts.FVS_VARIANT AS TREE_SPECIES_FVS_VARIANT, t.SPCD AS FIA_SPCD, ts.FVS_INPUT_SPCD INTO SPCD_CHANGE_WORK_TABLE ";
+		                string strSpcdSources =
+		                    "FROM ((" + strCondTableName + " AS c INNER JOIN " + strPlotTableName +
+		                    " AS p ON c.biosum_plot_id = p.biosum_plot_id) INNER JOIN " + strTreeTableName +
+		                    " AS t ON c.BIOSUM_COND_ID = t.biosum_cond_id) LEFT JOIN " + strTreeSpeciesTableName +
+		                    " AS ts ON t.SPCD = ts.SPCD ";
+		                string strSpcdConversionFilters =
+		                    "WHERE ts.FVS_VARIANT = p.FVS_VARIANT AND ts.FVS_INPUT_SPCD Is Not Null And ts.FVS_INPUT_SPCD <> t.SPCD;";
+		                string strSQL = strSelectIntoTempConversionTable + strSpcdSources + strSpcdConversionFilters;
+		                return strSQL;
+		            }
+
+
+		            public static string UpdateFVSSpeciesCodeColumn(string strVariant, string strFVSTreeInitWorkTable)
+		            {
+		                string strSQL = "UPDATE " + strFVSTreeInitWorkTable +
+		                                " AS fvstree INNER JOIN SPCD_CHANGE_WORK_TABLE AS spcdchange ON VAL(fvstree.SPECIES) = spcdchange.FIA_SPCD " +
+		                                "SET fvstree.SPECIES = CSTR(spcdchange.FVS_INPUT_SPCD) " +
+		                                "WHERE TRIM(spcdchange.PLOT_FVS_VARIANT)=\'" + strVariant.Trim().ToUpper() +
+		                                "\'; ";
+		                return strSQL;
+		            }
+
+		            public static string DeleteCrRatiosForDeadTrees(string strDestTable)
+		            {
+		                return "UPDATE " + strDestTable + " SET CrRatio=null WHERE History=9;";
+		            }
+
+		            public static string RoundCrRatioToSingleDigitCodes(string strDestTable)
+		            {
+		                /*This is a test to compare predispose and fvsin CrRatio when you round up*/
+		                string strSQL = "UPDATE " + strDestTable + " SET " +
+		                                "CrRatio=iif(crratio is null, null, iif(len(trim(cstr(crratio)))=0, 0, " +
+		                                "iif(0 <= crratio AND crratio <= 10, 1, " +
+		                                "iif(crratio <= 20, 2, " +
+		                                "iif(crratio <= 30, 3, " +
+		                                "iif(crratio <= 40, 4, " +
+		                                "iif(crratio <= 50, 5, " +
+		                                "iif(crratio <= 60, 6, " +
+		                                "iif(crratio <= 70, 7, " +
+		                                "iif(crratio <= 80, 8, " +
+		                                "iif(crratio <= 100, 9, null)))))))))));";
+		                return strSQL;
+		            }
+
+		            public static string DeleteHtAndHtTopKForNonMeasuredHeights(string strDestTable)
+		            {
+		                return "UPDATE " + strDestTable + " SET Ht=0, HtTopK=0 WHERE Htcd NOT IN (1,2,3);";
+		            }
+
+		            public static string SetBrokenTopFlag(string strDestTable)
+		            {
+		                return "UPDATE " + strDestTable +
+		                       " SET hasBrokenTop = -1 " + 
+		                       "WHERE HtTopK < Ht AND 0 < HtTopK;";
+		            }
+
+
+		            public static string SetHtTopKToZeroIfGteHt(string strDestTable)
+		            {
+		                return "UPDATE " + strDestTable + " SET HtTopK=0 WHERE Ht <= HtTopK";
+		            }
+
+
+		            public static string SetInferredSeedlingDbh(string strDestTable)
+		            {
+		                return "UPDATE " + strDestTable +
+		                       " SET Dbh=0.1 WHERE Tree_Count > 25 AND Dbh <= 0 AND History=1;";
+		            }
+
+		            public static string[] DamageCodes(string strDestTable)
+		            {
+		                string[] strDamageCodeUpdates = new string[15];
+
+		                //use precalculated damage codes if possible
+		                strDamageCodeUpdates[0] =
+		                    "UPDATE " + strDestTable +
+		                    " SET Damage1=fvs_dmg_ag1, Damage2=fvs_dmg_ag2, Damage3=fvs_dmg_ag3, Severity1=fvs_dmg_sv1, Severity2=fvs_dmg_sv2, Severity3=fvs_dmg_sv3 WHERE History=1 AND fvs_dmg_ag1 is not null;";
+
+		                //Cull board feet
+		                strDamageCodeUpdates[1] =
+		                    "UPDATE " + strDestTable +
+		                    " SET Damage1=25, Severity1=IIF(cullbf>=100, 99, cullbf) WHERE History=1 AND cullbf>0;";
+
+		                //FVS Mistletoe damage codes
+		                string strDamage1_Filter =
+		                    "History=1 AND iif(mist_cl_cd is null,0,mist_cl_cd) <> 0 AND Damage1 = 0 AND fvs_dmg_ag1 is null;";
+		                string strDamage2_Filter =
+		                    "History=1 AND iif(mist_cl_cd is null,0,mist_cl_cd) <> 0 AND Damage1 NOT IN (0, 30, 31, 32, 33, 34) AND fvs_dmg_ag1 is null;";
+		                strDamageCodeUpdates[2] =
+		                    "UPDATE " + strDestTable +
+		                    " SET Damage1=31, Severity1=mist_cl_cd WHERE Species=\'108\' AND " +
+		                    strDamage1_Filter;
+
+		                strDamageCodeUpdates[3] =
+		                    "UPDATE " + strDestTable +
+		                    " SET Damage2=31, Severity2=mist_cl_cd WHERE Species=\'108\' AND " +
+		                    strDamage2_Filter;
+
+		                strDamageCodeUpdates[4] =
+		                    "UPDATE " + strDestTable +
+		                    " SET Damage1=32, Severity1=mist_cl_cd WHERE Species=\'073\' AND " +
+		                    strDamage1_Filter;
+
+		                strDamageCodeUpdates[5] =
+		                    "UPDATE " + strDestTable +
+		                    " SET Damage2=32, Severity2=mist_cl_cd WHERE Species=\'073\' AND " +
+		                    strDamage2_Filter;
+
+		                strDamageCodeUpdates[6] =
+		                    "UPDATE " + strDestTable +
+		                    " SET Damage1=33, Severity1=mist_cl_cd WHERE Species=\'202\' AND " +
+		                    strDamage1_Filter;
+
+		                strDamageCodeUpdates[7] =
+		                    "UPDATE " + strDestTable +
+		                    " SET Damage2=33, Severity2=mist_cl_cd WHERE Species=\'202\' AND " +
+		                    strDamage2_Filter;
+
+		                strDamageCodeUpdates[8] =
+		                    "UPDATE " + strDestTable +
+		                    " SET Damage1=34, Severity1=mist_cl_cd WHERE Species=\'122\' AND " +
+		                    strDamage1_Filter;
+
+		                strDamageCodeUpdates[9] =
+		                    "UPDATE " + strDestTable +
+		                    " SET Damage2=34, Severity2=mist_cl_cd WHERE Species=\'122\' AND " +
+		                    strDamage2_Filter;
+
+		                //default mist_cl_cd damage code if fvs species don't match previous four cases
+		                strDamageCodeUpdates[10] =
+		                    "UPDATE " + strDestTable +
+		                    " SET Damage1=30, Severity1=mist_cl_cd WHERE Species NOT IN (\'202\',\'108\',\'122\',\'073\') AND " +
+		                    strDamage1_Filter;
+
+		                strDamageCodeUpdates[11] =
+		                    "UPDATE " + strDestTable +
+		                    " SET Damage2=30, Severity2=mist_cl_cd WHERE Species NOT IN (\'202\',\'108\',\'122\',\'073\') AND " +
+		                    strDamage2_Filter;
+
+		                //broken top 96 added to least priority(?) damage column so fill it last
+		                strDamageCodeUpdates[12] =
+		                    "UPDATE " + strDestTable +
+		                    " SET Damage1=96 WHERE History=1 AND hasBrokenTop AND Damage1 = 0 AND fvs_dmg_ag1 is null;";
+
+		                //0 means nothing was assigned. 96 means damage2 doesn't need to repeat damage1
+		                strDamageCodeUpdates[13] =
+		                    "UPDATE " + strDestTable +
+		                    " SET Damage2=96 WHERE History=1 AND hasBrokenTop AND Damage1 NOT IN (0,96) AND Damage2 = 0 AND fvs_dmg_ag1 IS Null;";
+
+		                strDamageCodeUpdates[14] =
+		                    "UPDATE " + strDestTable +
+		                    " SET Damage3=96 WHERE History=1 AND hasBrokenTop AND Damage1 NOT IN (0,96) AND Damage2 not in (0,96) and Damage3=0 AND fvs_dmg_ag1 IS Null;";
+		                /*END DAMAGE CODES*/
+		                return strDamageCodeUpdates;
+		            }
+
+		            public static string[] TreeValueClass(string strDestTable)
+		            {
+		                /*Value Classes: 
                           * All trees (live and dead) initialized to 3. 
                           * If Damage1=25, TreeValue=3 again (redundant). 
                           * Else if Severity > 0, TreeValue=2. 
                           * Else TreeValue=1*/
-                        string[] strTreeValueUpdates = new string[2];
-                        strTreeValueUpdates[0] = "UPDATE " + strDestTable +
-                                                 " SET TreeValue=2 WHERE History=1 AND Damage1<>25 AND Severity1>0;";
-                        strTreeValueUpdates[1] = "UPDATE " + strDestTable +
-                                                 " SET TreeValue=1 WHERE History=1 AND Damage1<>25 AND Severity1<=0;";
-                        return strTreeValueUpdates;
-                    }
+		                string[] strTreeValueUpdates = new string[2];
+		                strTreeValueUpdates[0] = "UPDATE " + strDestTable +
+		                                         " SET TreeValue=2 WHERE History=1 AND Damage1<>25 AND Severity1>0;";
+		                strTreeValueUpdates[1] = "UPDATE " + strDestTable +
+		                                         " SET TreeValue=1 WHERE History=1 AND Damage1<>25 AND Severity1<=0;";
+		                return strTreeValueUpdates;
+		            }
 
 
-                    public static string PadSpeciesWithZero(string strDestTable)
-                    {
-                        //This addresses a problem with FVSOut having incorrect Species Codes being translated into "2TD"
-                        //Update the Species column to Trim and "PadLeft" with 0s by Creating a "000" and concatenating with Trim(Species) and taking the rightmost 3 digits
-                        //Example: Right("000" & "17      ", 3) => "017". Species=="17      "  because the Species column is width 8 in FVSIn.accdb
-                        return "UPDATE " + strDestTable + " SET Species = Right(String(3, \'0\') & Trim(Species), 3);";
-                    }
+		            public static string PadSpeciesWithZero(string strDestTable)
+		            {
+		                //This addresses a problem with FVSOut having incorrect Species Codes being translated into "2TD"
+		                //Update the Species column to Trim and "PadLeft" with 0s by Creating a "000" and concatenating with Trim(Species) and taking the rightmost 3 digits
+		                //Example: Right("000" & "17      ", 3) => "017". Species=="17      "  because the Species column is width 8 in FVSIn.accdb
+		                return "UPDATE " + strDestTable + " SET Species = Right(String(3, \'0\') & Trim(Species), 3);";
+		            }
 
-                    public static string TranslateWorkTableToTreeInitTable(string strSourceTable, string strDestTable)
-                    {
-                        string strInsertIntoTreeInit =
-                            "INSERT INTO " + strDestTable +
-                            " (Stand_ID, StandPlot_ID, Tree_ID, Tree_Count, History, Species, " +
-                            "DBH, DG, Ht, HTG, HtTopK, CrRatio,  " +
-                            "Damage1, Severity1, Damage2, Severity2, Damage3, Severity3, " +
-                            "TreeValue, Prescription, Age, Slope, Aspect, PV_Code, TopoCode, SitePrep) ";
-                        string strBioSumWorkTableSelectStmt =
-                            "SELECT Stand_ID, StandPlot_ID, Tree_ID, Tree_Count, History, Species, " +
-                            "DBH, DG, Ht, HTG, HtTopK, CrRatio,  " +
-                            "Damage1, Severity1, Damage2, Severity2, Damage3, Severity3, " +
-                            "TreeValue, Prescription, Age, Slope, Aspect, PV_Code, TopoCode, SitePrep ";
-                        string strFromTableExpr = "FROM " + strSourceTable + ";";
-                        return strInsertIntoTreeInit + strBioSumWorkTableSelectStmt + strFromTableExpr;
-                    }
+		            public static string TranslateWorkTableToTreeInitTable(string strSourceTable, string strDestTable)
+		            {
+		                string strInsertIntoTreeInit =
+		                    "INSERT INTO " + strDestTable;
+		                string strBioSumWorkTableSelectStmt =
+		                    " SELECT Stand_ID, StandPlot_ID, Tree_ID, Tree_Count, History, Species, " +
+		                    "DBH, DG, Ht, HTG, HtTopK, CrRatio,  " +
+		                    "Damage1, Severity1, Damage2, Severity2, Damage3, Severity3, " +
+		                    "TreeValue, Prescription, Age, Slope, Aspect, PV_Code, TopoCode, SitePrep ";
+		                string strFromTableExpr = "FROM " + strSourceTable + ";";
+		                return strInsertIntoTreeInit + strBioSumWorkTableSelectStmt + strFromTableExpr;
+		            }
 
-                    public static string RoundSingleDigitPercentageCrRatiosUpTo10(string strDestTable)
-                    {
-                        return "UPDATE " + strDestTable + " SET CrRatio=10 WHERE CrRatio<10;";
-                    }
+		            public static string RoundSingleDigitPercentageCrRatiosUpTo10(string strDestTable)
+		            {
+		                return "UPDATE " + strDestTable + " SET CrRatio=10 WHERE CrRatio<10;";
+		            }
 
-                    public static string RoundSingleDigitPercentageCrRatiosDownTo1(string strDestTable)
-                    {
-                        return "UPDATE " + strDestTable + " SET CrRatio=1 WHERE CrRatio<10;";
-                    }
+		            public static string RoundSingleDigitPercentageCrRatiosDownTo1(string strDestTable)
+		            {
+		                return "UPDATE " + strDestTable + " SET CrRatio=1 WHERE CrRatio<10;";
+		            }
 
-                    public static string DeleteWorkTable()
-                    {
-                        return "DROP TABLE FVS_TreeInit_WorkTable;";
-                    }
+		            public static string DeleteWorkTable()
+		            {
+		                return "DROP TABLE FVS_TreeInit_WorkTable;";
+		            }
 
-                    public static string DeleteSpcdChangeWorkTable()
-                    {
-                        return "DROP TABLE SPCD_CHANGE_WORK_TABLE;";
-                    }
-                }
+		            public static string DeleteSpcdChangeWorkTable()
+		            {
+		                return "DROP TABLE SPCD_CHANGE_WORK_TABLE;";
+		            }
+		        }
 
-                //This updates the FVSIn.GroupAddFilesAndKeywords table so that they FVS keywords have the correct DSNIn value
-                public class GroupAddFilesAndKeywords
-                {
-                    public static string UpdateAllPlots(string strFVSInFileName)
-                    {
-                        return
-                            "UPDATE FVS_GroupAddFilesAndKeywords SET FVS_GroupAddFilesAndKeywords.FVSKeywords = " +
-                            "\"Database\" + Chr(13) + Chr(10) + \"DSNIn\" + Chr(13) + Chr(10) + \"" + strFVSInFileName +
-                            "\" + Chr(13) + Chr(10) + \"StandSQL\" + Chr(13) + Chr(10) + \"SELECT *\" + Chr(13) + Chr(10) + " +
-                            "\"FROM FVS_PlotInit\" + Chr(13) + Chr(10) + \"WHERE StandPlot_ID = '%StandID%'\" + Chr(13) + Chr(10) + " +
-                            "\"EndSQL\" + Chr(13) + Chr(10) + \"TreeSQL\" + Chr(13) + Chr(10) + \"SELECT *\" + Chr(13) + Chr(10) + " +
-                            "\"FROM FVS_TreeInit\" + Chr(13) + Chr(10) + \"WHERE StandPlot_ID = '%StandID%'\" + Chr(13) + Chr(10) + " +
-                            "\"EndSQL\" + Chr(13) + Chr(10) + \"END\" WHERE (FVS_GroupAddFilesAndKeywords.Groups=\"All_Plots\");";
-                    }
+		        //This updates the FVSIn.GroupAddFilesAndKeywords table so that they FVS keywords have the correct DSNIn value
+		        public class GroupAddFilesAndKeywords
+		        {
+		            public static string UpdateAllPlots(string strFVSInFileName)
+		            {
+		                return
+		                    "UPDATE FVS_GroupAddFilesAndKeywords SET FVS_GroupAddFilesAndKeywords.FVSKeywords = " +
+		                    "\"Database\" + Chr(13) + Chr(10) + \"DSNIn\" + Chr(13) + Chr(10) + \"" + strFVSInFileName +
+		                    "\" + Chr(13) + Chr(10) + \"StandSQL\" + Chr(13) + Chr(10) + \"SELECT *\" + Chr(13) + Chr(10) + " +
+		                    "\"FROM FVS_PlotInit\" + Chr(13) + Chr(10) + \"WHERE StandPlot_ID = '%StandID%'\" + Chr(13) + Chr(10) + " +
+		                    "\"EndSQL\" + Chr(13) + Chr(10) + \"TreeSQL\" + Chr(13) + Chr(10) + \"SELECT *\" + Chr(13) + Chr(10) + " +
+		                    "\"FROM FVS_TreeInit\" + Chr(13) + Chr(10) + \"WHERE StandPlot_ID = '%StandID%'\" + Chr(13) + Chr(10) + " +
+		                    "\"EndSQL\" + Chr(13) + Chr(10) + \"END\" WHERE (FVS_GroupAddFilesAndKeywords.Groups=\"All_Plots\");";
+		            }
 
-                    public static string UpdateAllStands(string strFVSInFileName)
-                    {
-                        return
-                            "UPDATE FVS_GroupAddFilesAndKeywords SET FVS_GroupAddFilesAndKeywords.FVSKeywords = " +
-                            "\"Database\" + Chr(13) + Chr(10) + \"DSNIn\" + Chr(13) + Chr(10) + \"" + strFVSInFileName +
-                            "\" + Chr(13) + Chr(10) + \"StandSQL\" + Chr(13) + Chr(10) + \"SELECT *\" + Chr(13) + Chr(10) + " +
-                            "\"FROM FVS_StandInit\" + Chr(13) + Chr(10) + \"WHERE Stand_ID = '%StandID%'\" + Chr(13) + Chr(10) + " +
-                            "\"EndSQL\" + Chr(13) + Chr(10) + \"TreeSQL\" + Chr(13) + Chr(10) + \"SELECT *\" + Chr(13) + Chr(10) + " +
-                            "\"FROM FVS_TreeInit\" + Chr(13) + Chr(10) + \"WHERE Stand_ID = '%StandID%'\" + Chr(13) + Chr(10) + " +
-                            "\"EndSQL\" + Chr(13) + Chr(10) + \"END\" WHERE (FVS_GroupAddFilesAndKeywords.Groups=\"All_Stands\");";
-                    }
-                }
-            }
+		            public static string UpdateAllStands(string strFVSInFileName)
+		            {
+		                return
+		                    "UPDATE FVS_GroupAddFilesAndKeywords SET FVS_GroupAddFilesAndKeywords.FVSKeywords = " +
+		                    "\"Database\" + Chr(13) + Chr(10) + \"DSNIn\" + Chr(13) + Chr(10) + \"" + strFVSInFileName +
+		                    "\" + Chr(13) + Chr(10) + \"StandSQL\" + Chr(13) + Chr(10) + \"SELECT *\" + Chr(13) + Chr(10) + " +
+		                    "\"FROM FVS_StandInit\" + Chr(13) + Chr(10) + \"WHERE Stand_ID = '%StandID%'\" + Chr(13) + Chr(10) + " +
+		                    "\"EndSQL\" + Chr(13) + Chr(10) + \"TreeSQL\" + Chr(13) + Chr(10) + \"SELECT *\" + Chr(13) + Chr(10) + " +
+		                    "\"FROM FVS_TreeInit\" + Chr(13) + Chr(10) + \"WHERE Stand_ID = '%StandID%'\" + Chr(13) + Chr(10) + " +
+		                    "\"EndSQL\" + Chr(13) + Chr(10) + \"END\" WHERE (FVS_GroupAddFilesAndKeywords.Groups=\"All_Stands\");";
+		            }
+		        }
+		    }
 
 		}
 		public class TravelTime

--- a/src/Tables.cs
+++ b/src/Tables.cs
@@ -2611,7 +2611,8 @@ namespace FIA_Biosum_Manager
                        "SmallMediumTotalLength DOUBLE," +
                        "LargeTotalLength DOUBLE," +
                        "CWDTotalLength DOUBLE," +
-                       "PitCount LONG," +
+                       "DuffPitCount LONG," +
+                       "LitterPitCount LONG," +
                        "Photo_Ref LONG," +
                        "Photo_code CHAR(13)" +
                        ")";
@@ -2643,8 +2644,8 @@ namespace FIA_Biosum_Manager
                        "TreeInitID AUTOINCREMENT, " + //Pkey and indexed
                        "Stand_ID CHAR(26)," + //indexed, duplicates okay //REQUIRED
                        "StandPlot_ID CHAR(40)," +
-                    //"Plot_ID CHAR(4)," + //RECOMMENDED (how FVS defines this field)
-                    //"Tree_ID CHAR(40)," + // (how FVS defines this field)
+                       //"Plot_ID CHAR(4)," + //RECOMMENDED (how FVS defines this field)
+                       //"Tree_ID CHAR(40)," + // (how FVS defines this field)
                        "Plot_ID DOUBLE," + //RECOMMENDED //This deviates from FVS DB documentation. Our current approach is to not use plot_IDs
                        "Tree_ID DOUBLE," + //This deviates from FVS DB documentation because we calculate Tree_ID as Tree.Subp*1000+Tree.Tree. Also indexed.
                        "Tree_Count DOUBLE," + //RECOMMENDED

--- a/src/datasource.cs
+++ b/src/datasource.cs
@@ -44,105 +44,115 @@ namespace FIA_Biosum_Manager
 		public int m_intNumberOfTables;
 		bool _bLoadFieldNamesAndDatatypes=false;
 		bool _bLoadTableRecordCount=true;
-		public static string[] g_strProjectDatasourceTableTypesArray = {"Plot",
-															  "Condition",
-															  "Tree",
-															  "Owner Groups",
-															  "Treatment Prescriptions",
-															  "Treatment Prescriptions Assigned FVS Commands",
-															  "Treatment Prescriptions Harvest Cost Columns",
-															  "Treatment Prescription Categories",
-															  "Treatment Prescription Subcategories",
-															  "Treatment Packages",
-															  "Treatment Package Assigned FVS Commands",
-															  "Treatment Package Members",
-															  "Treatment Package FVS Commands Order",
-															  "FVS Commands",
-                                                              "FVS PRE-POST SeqNum Definitions",
-                                                              "FVS PRE-POST SeqNum Treatment Package Assign", 
-															  "Tree Species",
-															  Datasource.TableTypes.FvsTreeSpecies,
-                                                              "FVS Western Tree Species Translator",
-                                                              "FVS Eastern Tree Species Translator",
-															  "Travel Times",
-															  "Processing Sites",
-															  "FVS Tree List For Processor",
-															  "FIADB FVS Variant",
-                                                              "FIA Tree Macro Plot Breakpoint Diameter",
-															  Datasource.TableTypes.HarvestMethods,
-															  "Plot And Condition Record Audit",
-															  "Plot, Condition And Treatment Record Audit",
-															  "Tree Regional Biomass",
-															  "Population Evaluation",
-															  "Population Estimation Unit",
-															  "Population Stratum",
-															  "Population Plot Stratum Assignment",
-                                                              "BIOSUM Pop Stratum Adjustment Factors",
-															  "Site Tree",
-                                                              Datasource.TableTypes.FiaTreeSpeciesReference};
+	    public static string[] g_strProjectDatasourceTableTypesArray =
+	    {
+			"Plot",
+			"Condition",
+			"Tree",
+			"Owner Groups",
+			"Treatment Prescriptions",
+			"Treatment Prescriptions Assigned FVS Commands",
+			"Treatment Prescriptions Harvest Cost Columns",
+			"Treatment Prescription Categories",
+			"Treatment Prescription Subcategories",
+			"Treatment Packages",
+			"Treatment Package Assigned FVS Commands",
+			"Treatment Package Members",
+			"Treatment Package FVS Commands Order",
+			"FVS Commands",
+			"FVS PRE-POST SeqNum Definitions",
+			"FVS PRE-POST SeqNum Treatment Package Assign", 
+			"Tree Species",
+			Datasource.TableTypes.FvsTreeSpecies,
+			"FVS Western Tree Species Translator",
+			"FVS Eastern Tree Species Translator",
+			"Travel Times",
+			"Processing Sites",
+			"FVS Tree List For Processor",
+			"FIADB FVS Variant",
+			"FIA Tree Macro Plot Breakpoint Diameter",
+			Datasource.TableTypes.HarvestMethods,
+			"Plot And Condition Record Audit",
+			"Plot, Condition And Treatment Record Audit",
+			"Tree Regional Biomass",
+			"Population Evaluation",
+			"Population Estimation Unit",
+			"Population Stratum",
+			"Population Plot Stratum Assignment",
+			"BIOSUM Pop Stratum Adjustment Factors",
+			"Site Tree",
+			Datasource.TableTypes.FiaTreeSpeciesReference,
+	    };
 
-        public static string[] g_strCoreDatasourceTableTypesArray = {"Plot",
-															  "Condition",
-															  "Tree",
-															  "Owner Groups",
-															  "Treatment Prescriptions",
-															  "Treatment Prescriptions Assigned FVS Commands",
-															  "Treatment Prescriptions Harvest Cost Columns",
-															  "Treatment Prescription Categories",
-															  "Treatment Prescription Subcategories",
-															  "Treatment Packages",
-															  "Treatment Package Assigned FVS Commands",
-															  "Treatment Package Members",
-															  "Treatment Package FVS Commands Order",
-															  "FVS Commands",
-															  "Tree Species",
-															  "FVS Tree Species",
-															  "Travel Times",
-															  "Processing Sites",
-															  "FVS Tree List For Processor",
-															  "FIADB FVS Variant",
-                                                              "FIA Tree Macro Plot Breakpoint Diameter",
-															  Datasource.TableTypes.HarvestMethods,
-															  "Plot And Condition Record Audit",
-															  "Plot, Condition And Treatment Record Audit",
-															  "Tree Regional Biomass",
-															  "Population Evaluation",
-															  "Population Estimation Unit",
-															  "Population Stratum",
-															  "Population Plot Stratum Assignment",
-                                                              "BIOSUM Pop Stratum Adjustment Factors",
-															  "Site Tree"};
-        public static string[] g_strProcessorDatasourceTableTypesArray = {"Plot",
-															  "Condition",
-															  "Tree",
-															  "Owner Groups",
-															  "Treatment Prescriptions",
-															  "Treatment Prescriptions Assigned FVS Commands",
-															  "Treatment Prescriptions Harvest Cost Columns",
-															  "Treatment Prescription Categories",
-															  "Treatment Prescription Subcategories",
-															  "Treatment Packages",
-															  "Treatment Package Assigned FVS Commands",
-															  "Treatment Package Members",
-															  "Treatment Package FVS Commands Order",
-															  "FVS Commands",
-															  "Tree Species",
-															  "FVS Tree Species",
-															  "Travel Times",
-															  "Processing Sites",
-															  "FVS Tree List For Processor",
-															  "FIADB FVS Variant",
-                                                              "FIA Tree Macro Plot Breakpoint Diameter",
-															  Datasource.TableTypes.HarvestMethods,
-															  "Plot And Condition Record Audit",
-															  "Plot, Condition And Treatment Record Audit",
-															  "Tree Regional Biomass",
-															  "Population Evaluation",
-															  "Population Estimation Unit",
-															  "Population Stratum",
-															  "Population Plot Stratum Assignment",
-                                                              "BIOSUM Pop Stratum Adjustment Factors",
-															  "Site Tree"};
+	    public static string[] g_strCoreDatasourceTableTypesArray =
+	    {
+	        "Plot",
+	        "Condition",
+	        "Tree",
+	        "Owner Groups",
+	        "Treatment Prescriptions",
+	        "Treatment Prescriptions Assigned FVS Commands",
+	        "Treatment Prescriptions Harvest Cost Columns",
+	        "Treatment Prescription Categories",
+	        "Treatment Prescription Subcategories",
+	        "Treatment Packages",
+	        "Treatment Package Assigned FVS Commands",
+	        "Treatment Package Members",
+	        "Treatment Package FVS Commands Order",
+	        "FVS Commands",
+	        "Tree Species",
+	        "FVS Tree Species",
+	        "Travel Times",
+	        "Processing Sites",
+	        "FVS Tree List For Processor",
+	        "FIADB FVS Variant",
+	        "FIA Tree Macro Plot Breakpoint Diameter",
+	        Datasource.TableTypes.HarvestMethods,
+	        "Plot And Condition Record Audit",
+	        "Plot, Condition And Treatment Record Audit",
+	        "Tree Regional Biomass",
+	        "Population Evaluation",
+	        "Population Estimation Unit",
+	        "Population Stratum",
+	        "Population Plot Stratum Assignment",
+	        "BIOSUM Pop Stratum Adjustment Factors",
+	        "Site Tree"
+	    };
+
+	    public static string[] g_strProcessorDatasourceTableTypesArray =
+	    {
+	        "Plot",
+	        "Condition",
+	        "Tree",
+	        "Owner Groups",
+	        "Treatment Prescriptions",
+	        "Treatment Prescriptions Assigned FVS Commands",
+	        "Treatment Prescriptions Harvest Cost Columns",
+	        "Treatment Prescription Categories",
+	        "Treatment Prescription Subcategories",
+	        "Treatment Packages",
+	        "Treatment Package Assigned FVS Commands",
+	        "Treatment Package Members",
+	        "Treatment Package FVS Commands Order",
+	        "FVS Commands",
+	        "Tree Species",
+	        "FVS Tree Species",
+	        "Travel Times",
+	        "Processing Sites",
+	        "FVS Tree List For Processor",
+	        "FIADB FVS Variant",
+	        "FIA Tree Macro Plot Breakpoint Diameter",
+	        Datasource.TableTypes.HarvestMethods,
+	        "Plot And Condition Record Audit",
+	        "Plot, Condition And Treatment Record Audit",
+	        "Tree Regional Biomass",
+	        "Population Evaluation",
+	        "Population Estimation Unit",
+	        "Population Stratum",
+	        "Population Plot Stratum Assignment",
+	        "BIOSUM Pop Stratum Adjustment Factors",
+	        "Site Tree"
+	    };
 		public static FIA_Biosum_Manager.SQLMacroSubstitutionVariableItem g_oCurrentSQLMacroSubstitutionVariableItem=
 			            new SQLMacroSubstitutionVariableItem();
 
@@ -232,14 +242,15 @@ namespace FIA_Biosum_Manager
 			intRecCnt = Convert.ToInt32(p_ado.getRecordCount(oConn,"select count(*) from " + this.m_strDataSourceTableName,this.m_strDataSourceTableName));
 			this.m_strDataSource = new String[intRecCnt,10];
 			System.Data.OleDb.OleDbCommand oCommand = oConn.CreateCommand();
-      if (this.m_strScenarioId.Trim().Length > 0)
-      {
-			oCommand.CommandText = "select table_type,path,file,table_name from scenario_datasource" + 
-				                   " where scenario_id = '" + this.m_strScenarioId.Trim() + "';";
-		  }
-		  else
-		  {
-			  oCommand.CommandText = "select table_type,path,file,table_name from " + this.m_strDataSourceTableName + ";" ;
+		    if (this.m_strScenarioId.Trim().Length > 0)
+		    {
+		        oCommand.CommandText = "select table_type,path,file,table_name from scenario_datasource" +
+		                               " where scenario_id = '" + this.m_strScenarioId.Trim() + "';";
+		    }
+		    else
+		    {
+		        oCommand.CommandText =
+		            "select table_type,path,file,table_name from " + this.m_strDataSourceTableName + ";";
 			}
 				                           
 			try
@@ -281,6 +292,9 @@ namespace FIA_Biosum_Manager
 									if (this.LoadTableRecordCount) this.m_strDataSource[x,RECORDCOUNT] = Convert.ToString(p_ado.getRecordCount(strConn,strSQL,oDataReader["table_name"].ToString()));
 									if (this.LoadTableColumnNamesAndDataTypes) p_ado.getFieldNamesAndDataTypes(strConn,"select * from " + oDataReader["table_name"].ToString(), ref this.m_strDataSource[x,COLUMN_LIST],ref this.m_strDataSource[x,DATATYPE_LIST]);
 									p_ado.CloseConnection(p_ado.m_OleDbConnection);
+								    while (p_ado.m_OleDbConnection.State != ConnectionState.Closed)
+								        System.Threading.Thread.Sleep(5000);
+								    p_ado.m_OleDbConnection.Dispose();
 								}
 							}
 						}
@@ -289,8 +303,10 @@ namespace FIA_Biosum_Manager
 							this.m_strDataSource[x,TABLESTATUS] = "NF";
 							this.m_strDataSource[x,RECORDCOUNT] = "0";
 						}
-						p_dao.m_DaoWorkspace.Close();
-						p_dao = null;
+					    if (p_dao.m_DaoWorkspace != null)
+					    {
+					        p_dao.m_DaoWorkspace.Close();
+					    } p_dao = null;
 					}
 					else 
 					{
@@ -304,6 +320,7 @@ namespace FIA_Biosum_Manager
 					x++;
 				}
 				oDataReader.Close();
+                oDataReader.Dispose();
 			}
 			catch
 			{
@@ -317,7 +334,7 @@ namespace FIA_Biosum_Manager
 						oConn.Close();
 						while (oConn.State != System.Data.ConnectionState.Closed)
 							System.Threading.Thread.Sleep(1000);
-
+                        oConn.Dispose();
 						oConn = null;
 					}
 				}
@@ -333,7 +350,7 @@ namespace FIA_Biosum_Manager
 						oConn.Close();
 						while (oConn.State != System.Data.ConnectionState.Closed)
 							System.Threading.Thread.Sleep(1000);
-
+                        oConn.Dispose();
 						oConn = null;
 					}
 				}

--- a/src/uc_delete_conditions.Designer.cs
+++ b/src/uc_delete_conditions.Designer.cs
@@ -60,8 +60,9 @@
             this.btnFilterByFileBrowse = new System.Windows.Forms.Button();
             this.txtFilterByFile = new System.Windows.Forms.TextBox();
             this.rdoFilterByFile = new System.Windows.Forms.RadioButton();
-            this.rdoDeleteAllConds = new System.Windows.Forms.RadioButton();
             this.rdoFilterByMenu = new System.Windows.Forms.RadioButton();
+            this.rdoDeleteAllConds = new System.Windows.Forms.RadioButton();
+            this.chkCreateLog = new System.Windows.Forms.CheckBox();
             this.groupBox1.SuspendLayout();
             this.grpboxFilterByState.SuspendLayout();
             this.grpboxFilterByCondId.SuspendLayout();
@@ -340,6 +341,7 @@
             // 
             // grpboxFilterOptions
             // 
+            this.grpboxFilterOptions.Controls.Add(this.chkCreateLog);
             this.grpboxFilterOptions.Controls.Add(this.label1);
             this.grpboxFilterOptions.Controls.Add(this.btnFilterByFileBrowse);
             this.grpboxFilterOptions.Controls.Add(this.txtFilterByFile);
@@ -393,6 +395,17 @@
             this.rdoFilterByFile.Text = "Delete Conditions with Text File of Cond.CN values";
             this.rdoFilterByFile.Click += new System.EventHandler(this.rdoFilterByFile_Click);
             // 
+            // rdoFilterByMenu
+            // 
+            this.rdoFilterByMenu.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.rdoFilterByMenu.Location = new System.Drawing.Point(51, 182);
+            this.rdoFilterByMenu.Name = "rdoFilterByMenu";
+            this.rdoFilterByMenu.Size = new System.Drawing.Size(400, 32);
+            this.rdoFilterByMenu.TabIndex = 1;
+            this.rdoFilterByMenu.Text = "Delete Conditions By Menu Selection";
+            this.rdoFilterByMenu.Visible = false;
+            this.rdoFilterByMenu.Click += new System.EventHandler(this.rdoFilterByMenu_Click);
+            // 
             // rdoDeleteAllConds
             // 
             this.rdoDeleteAllConds.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
@@ -404,16 +417,17 @@
             this.rdoDeleteAllConds.Visible = false;
             this.rdoDeleteAllConds.Click += new System.EventHandler(this.rdoDeleteAllConds_Click);
             // 
-            // rdoFilterByMenu
+            // chkCreateLog
             // 
-            this.rdoFilterByMenu.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.rdoFilterByMenu.Location = new System.Drawing.Point(51, 182);
-            this.rdoFilterByMenu.Name = "rdoFilterByMenu";
-            this.rdoFilterByMenu.Size = new System.Drawing.Size(400, 32);
-            this.rdoFilterByMenu.TabIndex = 1;
-            this.rdoFilterByMenu.Text = "Delete Conditions By Menu Selection";
-            this.rdoFilterByMenu.Visible = false;
-            this.rdoFilterByMenu.Click += new System.EventHandler(this.rdoFilterByMenu_Click);
+            this.chkCreateLog.AutoSize = true;
+            this.chkCreateLog.Checked = true;
+            this.chkCreateLog.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkCreateLog.Location = new System.Drawing.Point(51, 220);
+            this.chkCreateLog.Name = "chkCreateLog";
+            this.chkCreateLog.Size = new System.Drawing.Size(97, 17);
+            this.chkCreateLog.TabIndex = 7;
+            this.chkCreateLog.Text = "Create Log File";
+            this.chkCreateLog.UseVisualStyleBackColor = true;
             // 
             // uc_delete_conditions
             // 
@@ -466,5 +480,6 @@
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.RadioButton rdoFilterByMenu;
         private System.Windows.Forms.RadioButton rdoDeleteAllConds;
+        private System.Windows.Forms.CheckBox chkCreateLog;
     }
 }

--- a/src/uc_fvs_input.cs
+++ b/src/uc_fvs_input.cs
@@ -93,6 +93,26 @@ namespace FIA_Biosum_Manager
         private env m_oEnv;
         private Help m_oHelp;
         private string m_xpsFile = Help.DefaultFvsXPSFile;
+        private TextBox txtMinCwdTL;
+        private TextBox txtMinSmallFwdTL;
+        private TextBox txtMinLargeFwdTL;
+        private Label label4;
+        private Label label3;
+        private Label label2;
+        private TabControl tabControl1;
+        private TabPage tabPage1;
+        private TabPage tabPage2;
+        private GroupBox grpDWMOptions;
+        private CheckBox chkDwmFuelModel;
+        private CheckBox chkDwmFuelBiomass;
+        private CheckedListBox chkLstBoxLitterYears;
+        private CheckedListBox chkLstBoxDuffYears;
+        private GroupBox groupBox2;
+        private Label label6;
+        private Label label5;
+        private LinkLabel linkLabelFuelModel;
+
+        delegate string[] GetListBoxItemsDlg(CheckedListBox checkedListBox);
 
 		/// <summary> 
 		/// Required designer variable.
@@ -116,6 +136,11 @@ namespace FIA_Biosum_Manager
 
             this.m_oEnv = new env();
 
+		    for (int i = 2001; i <= DateTime.Now.Year; i++)
+		    {
+		        this.chkLstBoxDuffYears.Items.Add(i.ToString());
+		        this.chkLstBoxLitterYears.Items.Add(i.ToString());
+		    }
 
 			// TODO: Add any initialization after the InitializeComponent call
 
@@ -144,70 +169,152 @@ namespace FIA_Biosum_Manager
 		private void InitializeComponent()
 		{
             this.groupBox1 = new System.Windows.Forms.GroupBox();
-            this.btnExecuteAction = new System.Windows.Forms.Button();
-            this.cmbAction = new System.Windows.Forms.ComboBox();
-            this.txtDataDir = new System.Windows.Forms.TextBox();
-            this.label1 = new System.Windows.Forms.Label();
-            this.btnRxPackage = new System.Windows.Forms.Button();
-            this.lblRxPackageCnt = new System.Windows.Forms.Label();
-            this.btnRx = new System.Windows.Forms.Button();
-            this.btnTreeSpcVariants = new System.Windows.Forms.Button();
+            this.tabControl1 = new System.Windows.Forms.TabControl();
+            this.tabPage2 = new System.Windows.Forms.TabPage();
             this.btnPlotVariants = new System.Windows.Forms.Button();
+            this.txtDataDir = new System.Windows.Forms.TextBox();
+            this.btnExecuteAction = new System.Windows.Forms.Button();
+            this.lstFvsInput = new System.Windows.Forms.ListView();
+            this.cmbAction = new System.Windows.Forms.ComboBox();
+            this.lblRxCnt = new System.Windows.Forms.Label();
+            this.lblVarCnt = new System.Windows.Forms.Label();
+            this.label1 = new System.Windows.Forms.Label();
+            this.btnChkAll = new System.Windows.Forms.Button();
+            this.btnRxPackage = new System.Windows.Forms.Button();
+            this.btnClearAll = new System.Windows.Forms.Button();
+            this.lblRxPackageCnt = new System.Windows.Forms.Label();
+            this.btnRefresh = new System.Windows.Forms.Button();
+            this.btnRx = new System.Windows.Forms.Button();
             this.lblTreeSpcVarCnt = new System.Windows.Forms.Label();
+            this.btnTreeSpcVariants = new System.Windows.Forms.Button();
+            this.tabPage1 = new System.Windows.Forms.TabPage();
+            this.grpDWMOptions = new System.Windows.Forms.GroupBox();
+            this.linkLabelFuelModel = new System.Windows.Forms.LinkLabel();
+            this.groupBox2 = new System.Windows.Forms.GroupBox();
+            this.label6 = new System.Windows.Forms.Label();
+            this.label5 = new System.Windows.Forms.Label();
+            this.chkLstBoxDuffYears = new System.Windows.Forms.CheckedListBox();
+            this.chkLstBoxLitterYears = new System.Windows.Forms.CheckedListBox();
+            this.chkDwmFuelModel = new System.Windows.Forms.CheckBox();
+            this.chkDwmFuelBiomass = new System.Windows.Forms.CheckBox();
+            this.label4 = new System.Windows.Forms.Label();
+            this.label2 = new System.Windows.Forms.Label();
+            this.txtMinLargeFwdTL = new System.Windows.Forms.TextBox();
+            this.txtMinCwdTL = new System.Windows.Forms.TextBox();
+            this.label3 = new System.Windows.Forms.Label();
+            this.txtMinSmallFwdTL = new System.Windows.Forms.TextBox();
             this.btnCancel = new System.Windows.Forms.Button();
             this.progressBar1 = new System.Windows.Forms.ProgressBar();
             this.lblProgress = new System.Windows.Forms.Label();
             this.btnHelp = new System.Windows.Forms.Button();
-            this.btnRefresh = new System.Windows.Forms.Button();
-            this.btnClearAll = new System.Windows.Forms.Button();
-            this.btnChkAll = new System.Windows.Forms.Button();
             this.btnClose = new System.Windows.Forms.Button();
-            this.lblVarCnt = new System.Windows.Forms.Label();
-            this.lblRxCnt = new System.Windows.Forms.Label();
-            this.lstFvsInput = new System.Windows.Forms.ListView();
             this.lblTitle = new System.Windows.Forms.Label();
             this.groupBox1.SuspendLayout();
+            this.tabControl1.SuspendLayout();
+            this.tabPage2.SuspendLayout();
+            this.tabPage1.SuspendLayout();
+            this.grpDWMOptions.SuspendLayout();
+            this.groupBox2.SuspendLayout();
             this.SuspendLayout();
             // 
             // groupBox1
             // 
-            this.groupBox1.Controls.Add(this.btnExecuteAction);
-            this.groupBox1.Controls.Add(this.cmbAction);
-            this.groupBox1.Controls.Add(this.txtDataDir);
-            this.groupBox1.Controls.Add(this.label1);
-            this.groupBox1.Controls.Add(this.btnRxPackage);
-            this.groupBox1.Controls.Add(this.lblRxPackageCnt);
-            this.groupBox1.Controls.Add(this.btnRx);
-            this.groupBox1.Controls.Add(this.btnTreeSpcVariants);
-            this.groupBox1.Controls.Add(this.btnPlotVariants);
-            this.groupBox1.Controls.Add(this.lblTreeSpcVarCnt);
+            this.groupBox1.Controls.Add(this.tabControl1);
             this.groupBox1.Controls.Add(this.btnCancel);
             this.groupBox1.Controls.Add(this.progressBar1);
             this.groupBox1.Controls.Add(this.lblProgress);
             this.groupBox1.Controls.Add(this.btnHelp);
-            this.groupBox1.Controls.Add(this.btnRefresh);
-            this.groupBox1.Controls.Add(this.btnClearAll);
-            this.groupBox1.Controls.Add(this.btnChkAll);
             this.groupBox1.Controls.Add(this.btnClose);
-            this.groupBox1.Controls.Add(this.lblVarCnt);
-            this.groupBox1.Controls.Add(this.lblRxCnt);
-            this.groupBox1.Controls.Add(this.lstFvsInput);
             this.groupBox1.Controls.Add(this.lblTitle);
             this.groupBox1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.groupBox1.Location = new System.Drawing.Point(0, 0);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(784, 616);
-            this.groupBox1.TabIndex = 0;
+            this.groupBox1.Size = new System.Drawing.Size(784, 585);
+            this.groupBox1.TabIndex = 99;
             this.groupBox1.TabStop = false;
+            this.groupBox1.Enter += new System.EventHandler(this.groupBox1_Enter);
+            // 
+            // tabControl1
+            // 
+            this.tabControl1.Controls.Add(this.tabPage2);
+            this.tabControl1.Controls.Add(this.tabPage1);
+            this.tabControl1.Location = new System.Drawing.Point(7, 51);
+            this.tabControl1.Name = "tabControl1";
+            this.tabControl1.SelectedIndex = 0;
+            this.tabControl1.Size = new System.Drawing.Size(771, 483);
+            this.tabControl1.TabIndex = 100;
+            this.tabControl1.TabIndexChanged += new System.EventHandler(this.tabControl1_TabIndexChanged);
+            this.tabControl1.Resize += new System.EventHandler(this.tabControl1_Resize);
+            // 
+            // tabPage2
+            // 
+            this.tabPage2.Controls.Add(this.btnPlotVariants);
+            this.tabPage2.Controls.Add(this.txtDataDir);
+            this.tabPage2.Controls.Add(this.btnExecuteAction);
+            this.tabPage2.Controls.Add(this.lstFvsInput);
+            this.tabPage2.Controls.Add(this.cmbAction);
+            this.tabPage2.Controls.Add(this.lblRxCnt);
+            this.tabPage2.Controls.Add(this.lblVarCnt);
+            this.tabPage2.Controls.Add(this.label1);
+            this.tabPage2.Controls.Add(this.btnChkAll);
+            this.tabPage2.Controls.Add(this.btnRxPackage);
+            this.tabPage2.Controls.Add(this.btnClearAll);
+            this.tabPage2.Controls.Add(this.lblRxPackageCnt);
+            this.tabPage2.Controls.Add(this.btnRefresh);
+            this.tabPage2.Controls.Add(this.btnRx);
+            this.tabPage2.Controls.Add(this.lblTreeSpcVarCnt);
+            this.tabPage2.Controls.Add(this.btnTreeSpcVariants);
+            this.tabPage2.Location = new System.Drawing.Point(4, 22);
+            this.tabPage2.Name = "tabPage2";
+            this.tabPage2.Padding = new System.Windows.Forms.Padding(3);
+            this.tabPage2.Size = new System.Drawing.Size(763, 457);
+            this.tabPage2.TabIndex = 1;
+            this.tabPage2.Text = "Main Menu";
+            this.tabPage2.UseVisualStyleBackColor = true;
+            this.tabPage2.SizeChanged += new System.EventHandler(this.tabControl1_Resize);
+            // 
+            // btnPlotVariants
+            // 
+            this.btnPlotVariants.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btnPlotVariants.Location = new System.Drawing.Point(6, 6);
+            this.btnPlotVariants.Name = "btnPlotVariants";
+            this.btnPlotVariants.Size = new System.Drawing.Size(232, 24);
+            this.btnPlotVariants.TabIndex = 99;
+            this.btnPlotVariants.Text = "Plots Missing FVS Variant Value";
+            this.btnPlotVariants.Click += new System.EventHandler(this.btnPlotVariants_Click);
+            // 
+            // txtDataDir
+            // 
+            this.txtDataDir.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.txtDataDir.Location = new System.Drawing.Point(96, 60);
+            this.txtDataDir.Name = "txtDataDir";
+            this.txtDataDir.Size = new System.Drawing.Size(661, 20);
+            this.txtDataDir.TabIndex = 99;
             // 
             // btnExecuteAction
             // 
-            this.btnExecuteAction.Location = new System.Drawing.Point(680, 501);
+            this.btnExecuteAction.Location = new System.Drawing.Point(669, 332);
             this.btnExecuteAction.Name = "btnExecuteAction";
             this.btnExecuteAction.Size = new System.Drawing.Size(88, 32);
-            this.btnExecuteAction.TabIndex = 63;
+            this.btnExecuteAction.TabIndex = 5;
             this.btnExecuteAction.Text = "Execute Action";
             this.btnExecuteAction.Click += new System.EventHandler(this.btnExecuteAction_Click);
+            // 
+            // lstFvsInput
+            // 
+            this.lstFvsInput.CheckBoxes = true;
+            this.lstFvsInput.GridLines = true;
+            this.lstFvsInput.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.Nonclickable;
+            this.lstFvsInput.HideSelection = false;
+            this.lstFvsInput.Location = new System.Drawing.Point(6, 87);
+            this.lstFvsInput.MultiSelect = false;
+            this.lstFvsInput.Name = "lstFvsInput";
+            this.lstFvsInput.Size = new System.Drawing.Size(751, 239);
+            this.lstFvsInput.TabIndex = 0;
+            this.lstFvsInput.UseCompatibleStateImageBehavior = false;
+            this.lstFvsInput.View = System.Windows.Forms.View.Details;
+            this.lstFvsInput.SelectedIndexChanged += new System.EventHandler(this.lstFvsInput_SelectedIndexChanged);
+            this.lstFvsInput.MouseUp += new System.Windows.Forms.MouseEventHandler(this.lstFvsInput_MouseUp);
             // 
             // cmbAction
             // 
@@ -220,199 +327,334 @@ namespace FIA_Biosum_Manager
             "Delete Both Standard and POTFIRE Base Year Output Tables",
             "Write KCP Template Scripts",
             "View KCP Template Scripts"});
-            this.cmbAction.Location = new System.Drawing.Point(312, 508);
+            this.cmbAction.Location = new System.Drawing.Point(301, 339);
             this.cmbAction.Name = "cmbAction";
             this.cmbAction.Size = new System.Drawing.Size(362, 21);
-            this.cmbAction.TabIndex = 62;
+            this.cmbAction.TabIndex = 4;
             this.cmbAction.Text = "<-------Action Items------->";
             this.cmbAction.SelectedIndexChanged += new System.EventHandler(this.cmbAction_SelectedIndexChanged);
             this.cmbAction.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.cmbAction_KeyPress);
             // 
-            // txtDataDir
+            // lblRxCnt
             // 
-            this.txtDataDir.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.txtDataDir.Location = new System.Drawing.Point(136, 120);
-            this.txtDataDir.Name = "txtDataDir";
-            this.txtDataDir.Size = new System.Drawing.Size(632, 20);
-            this.txtDataDir.TabIndex = 60;
+            this.lblRxCnt.BackColor = System.Drawing.Color.White;
+            this.lblRxCnt.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lblRxCnt.Location = new System.Drawing.Point(400, 10);
+            this.lblRxCnt.Name = "lblRxCnt";
+            this.lblRxCnt.Size = new System.Drawing.Size(32, 16);
+            this.lblRxCnt.TabIndex = 99;
+            this.lblRxCnt.Text = "0";
+            // 
+            // lblVarCnt
+            // 
+            this.lblVarCnt.BackColor = System.Drawing.Color.White;
+            this.lblVarCnt.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lblVarCnt.Location = new System.Drawing.Point(244, 10);
+            this.lblVarCnt.Name = "lblVarCnt";
+            this.lblVarCnt.Size = new System.Drawing.Size(56, 16);
+            this.lblVarCnt.TabIndex = 99;
+            this.lblVarCnt.Text = "0";
             // 
             // label1
             // 
             this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label1.Location = new System.Drawing.Point(24, 120);
+            this.label1.Location = new System.Drawing.Point(6, 63);
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(96, 24);
-            this.label1.TabIndex = 59;
+            this.label1.TabIndex = 99;
             this.label1.Text = "Data Directory";
+            // 
+            // btnChkAll
+            // 
+            this.btnChkAll.Location = new System.Drawing.Point(6, 332);
+            this.btnChkAll.Name = "btnChkAll";
+            this.btnChkAll.Size = new System.Drawing.Size(64, 32);
+            this.btnChkAll.TabIndex = 1;
+            this.btnChkAll.Text = "Check All";
+            this.btnChkAll.Click += new System.EventHandler(this.btnChkAll_Click);
             // 
             // btnRxPackage
             // 
             this.btnRxPackage.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.btnRxPackage.Location = new System.Drawing.Point(320, 78);
+            this.btnRxPackage.Location = new System.Drawing.Point(305, 30);
             this.btnRxPackage.Name = "btnRxPackage";
             this.btnRxPackage.Size = new System.Drawing.Size(90, 24);
-            this.btnRxPackage.TabIndex = 58;
+            this.btnRxPackage.TabIndex = 99;
             this.btnRxPackage.Text = "Packages";
             this.btnRxPackage.Click += new System.EventHandler(this.btnRxPackage_Click);
+            // 
+            // btnClearAll
+            // 
+            this.btnClearAll.Location = new System.Drawing.Point(69, 332);
+            this.btnClearAll.Name = "btnClearAll";
+            this.btnClearAll.Size = new System.Drawing.Size(64, 32);
+            this.btnClearAll.TabIndex = 2;
+            this.btnClearAll.Text = "Clear All";
+            this.btnClearAll.Click += new System.EventHandler(this.btnClearAll_Click);
             // 
             // lblRxPackageCnt
             // 
             this.lblRxPackageCnt.BackColor = System.Drawing.Color.White;
             this.lblRxPackageCnt.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lblRxPackageCnt.Location = new System.Drawing.Point(415, 80);
+            this.lblRxPackageCnt.Location = new System.Drawing.Point(400, 32);
             this.lblRxPackageCnt.Name = "lblRxPackageCnt";
             this.lblRxPackageCnt.Size = new System.Drawing.Size(32, 16);
-            this.lblRxPackageCnt.TabIndex = 57;
+            this.lblRxPackageCnt.TabIndex = 99;
             this.lblRxPackageCnt.Text = "0";
+            // 
+            // btnRefresh
+            // 
+            this.btnRefresh.Location = new System.Drawing.Point(132, 332);
+            this.btnRefresh.Name = "btnRefresh";
+            this.btnRefresh.Size = new System.Drawing.Size(64, 32);
+            this.btnRefresh.TabIndex = 3;
+            this.btnRefresh.Text = "Refresh";
+            this.btnRefresh.Click += new System.EventHandler(this.btnRefresh_Click);
             // 
             // btnRx
             // 
             this.btnRx.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.btnRx.Location = new System.Drawing.Point(320, 54);
+            this.btnRx.Location = new System.Drawing.Point(305, 6);
             this.btnRx.Name = "btnRx";
             this.btnRx.Size = new System.Drawing.Size(90, 24);
-            this.btnRx.TabIndex = 55;
+            this.btnRx.TabIndex = 99;
             this.btnRx.Text = "Treatments";
             this.btnRx.Click += new System.EventHandler(this.btnRx_Click);
-            // 
-            // btnTreeSpcVariants
-            // 
-            this.btnTreeSpcVariants.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.btnTreeSpcVariants.Location = new System.Drawing.Point(16, 78);
-            this.btnTreeSpcVariants.Name = "btnTreeSpcVariants";
-            this.btnTreeSpcVariants.Size = new System.Drawing.Size(232, 24);
-            this.btnTreeSpcVariants.TabIndex = 54;
-            this.btnTreeSpcVariants.Text = "Tree Species Missing FVS Variant Value";
-            this.btnTreeSpcVariants.Click += new System.EventHandler(this.btnTreeSpcVariants_Click);
-            // 
-            // btnPlotVariants
-            // 
-            this.btnPlotVariants.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.btnPlotVariants.Location = new System.Drawing.Point(16, 54);
-            this.btnPlotVariants.Name = "btnPlotVariants";
-            this.btnPlotVariants.Size = new System.Drawing.Size(232, 24);
-            this.btnPlotVariants.TabIndex = 53;
-            this.btnPlotVariants.Text = "Plots Missing FVS Variant Value";
-            this.btnPlotVariants.Click += new System.EventHandler(this.btnPlotVariants_Click);
             // 
             // lblTreeSpcVarCnt
             // 
             this.lblTreeSpcVarCnt.BackColor = System.Drawing.Color.White;
             this.lblTreeSpcVarCnt.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lblTreeSpcVarCnt.Location = new System.Drawing.Point(253, 80);
+            this.lblTreeSpcVarCnt.Location = new System.Drawing.Point(243, 32);
             this.lblTreeSpcVarCnt.Name = "lblTreeSpcVarCnt";
             this.lblTreeSpcVarCnt.Size = new System.Drawing.Size(56, 16);
-            this.lblTreeSpcVarCnt.TabIndex = 51;
+            this.lblTreeSpcVarCnt.TabIndex = 99;
             this.lblTreeSpcVarCnt.Text = "0";
+            // 
+            // btnTreeSpcVariants
+            // 
+            this.btnTreeSpcVariants.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btnTreeSpcVariants.Location = new System.Drawing.Point(6, 30);
+            this.btnTreeSpcVariants.Name = "btnTreeSpcVariants";
+            this.btnTreeSpcVariants.Size = new System.Drawing.Size(232, 24);
+            this.btnTreeSpcVariants.TabIndex = 99;
+            this.btnTreeSpcVariants.Text = "Tree Species Missing FVS Variant Value";
+            this.btnTreeSpcVariants.Click += new System.EventHandler(this.btnTreeSpcVariants_Click);
+            // 
+            // tabPage1
+            // 
+            this.tabPage1.Controls.Add(this.grpDWMOptions);
+            this.tabPage1.Location = new System.Drawing.Point(4, 22);
+            this.tabPage1.Name = "tabPage1";
+            this.tabPage1.Padding = new System.Windows.Forms.Padding(3);
+            this.tabPage1.Size = new System.Drawing.Size(763, 457);
+            this.tabPage1.TabIndex = 0;
+            this.tabPage1.Text = "Options";
+            this.tabPage1.UseVisualStyleBackColor = true;
+            // 
+            // grpDWMOptions
+            // 
+            this.grpDWMOptions.Controls.Add(this.linkLabelFuelModel);
+            this.grpDWMOptions.Controls.Add(this.groupBox2);
+            this.grpDWMOptions.Controls.Add(this.chkDwmFuelModel);
+            this.grpDWMOptions.Controls.Add(this.chkDwmFuelBiomass);
+            this.grpDWMOptions.Controls.Add(this.label4);
+            this.grpDWMOptions.Controls.Add(this.label2);
+            this.grpDWMOptions.Controls.Add(this.txtMinLargeFwdTL);
+            this.grpDWMOptions.Controls.Add(this.txtMinCwdTL);
+            this.grpDWMOptions.Controls.Add(this.label3);
+            this.grpDWMOptions.Controls.Add(this.txtMinSmallFwdTL);
+            this.grpDWMOptions.Location = new System.Drawing.Point(6, 6);
+            this.grpDWMOptions.Name = "grpDWMOptions";
+            this.grpDWMOptions.Size = new System.Drawing.Size(439, 378);
+            this.grpDWMOptions.TabIndex = 101;
+            this.grpDWMOptions.TabStop = false;
+            this.grpDWMOptions.Text = "Down Woody Material";
+            // 
+            // linkLabelFuelModel
+            // 
+            this.linkLabelFuelModel.AutoSize = true;
+            this.linkLabelFuelModel.LinkArea = new System.Windows.Forms.LinkArea(8, 23);
+            this.linkLabelFuelModel.Location = new System.Drawing.Point(23, 20);
+            this.linkLabelFuelModel.Name = "linkLabelFuelModel";
+            this.linkLabelFuelModel.Size = new System.Drawing.Size(404, 17);
+            this.linkLabelFuelModel.TabIndex = 105;
+            this.linkLabelFuelModel.TabStop = true;
+            this.linkLabelFuelModel.Text = "Include Scott and Burgan (2005) surface fuel model (from DWM_fuelbed_typcd)";
+            this.linkLabelFuelModel.UseCompatibleTextRendering = true;
+            this.linkLabelFuelModel.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkLabelFuelModel_LinkClicked);
+            // 
+            // groupBox2
+            // 
+            this.groupBox2.Controls.Add(this.label6);
+            this.groupBox2.Controls.Add(this.label5);
+            this.groupBox2.Controls.Add(this.chkLstBoxDuffYears);
+            this.groupBox2.Controls.Add(this.chkLstBoxLitterYears);
+            this.groupBox2.Location = new System.Drawing.Point(7, 142);
+            this.groupBox2.Name = "groupBox2";
+            this.groupBox2.Size = new System.Drawing.Size(236, 229);
+            this.groupBox2.TabIndex = 104;
+            this.groupBox2.TabStop = false;
+            this.groupBox2.Text = "Duff/Litter Years to Exclude";
+            // 
+            // label6
+            // 
+            this.label6.AutoSize = true;
+            this.label6.Location = new System.Drawing.Point(123, 16);
+            this.label6.Name = "label6";
+            this.label6.Size = new System.Drawing.Size(30, 13);
+            this.label6.TabIndex = 105;
+            this.label6.Text = "Litter";
+            // 
+            // label5
+            // 
+            this.label5.AutoSize = true;
+            this.label5.Location = new System.Drawing.Point(6, 16);
+            this.label5.Name = "label5";
+            this.label5.Size = new System.Drawing.Size(27, 13);
+            this.label5.TabIndex = 104;
+            this.label5.Text = "Duff";
+            // 
+            // chkLstBoxDuffYears
+            // 
+            this.chkLstBoxDuffYears.FormattingEnabled = true;
+            this.chkLstBoxDuffYears.Location = new System.Drawing.Point(9, 35);
+            this.chkLstBoxDuffYears.Name = "chkLstBoxDuffYears";
+            this.chkLstBoxDuffYears.Size = new System.Drawing.Size(100, 184);
+            this.chkLstBoxDuffYears.TabIndex = 6;
+            // 
+            // chkLstBoxLitterYears
+            // 
+            this.chkLstBoxLitterYears.FormattingEnabled = true;
+            this.chkLstBoxLitterYears.Location = new System.Drawing.Point(126, 35);
+            this.chkLstBoxLitterYears.Name = "chkLstBoxLitterYears";
+            this.chkLstBoxLitterYears.Size = new System.Drawing.Size(100, 184);
+            this.chkLstBoxLitterYears.TabIndex = 7;
+            // 
+            // chkDwmFuelModel
+            // 
+            this.chkDwmFuelModel.AutoSize = true;
+            this.chkDwmFuelModel.Location = new System.Drawing.Point(7, 19);
+            this.chkDwmFuelModel.Name = "chkDwmFuelModel";
+            this.chkDwmFuelModel.Size = new System.Drawing.Size(15, 14);
+            this.chkDwmFuelModel.TabIndex = 1;
+            this.chkDwmFuelModel.UseVisualStyleBackColor = true;
+            // 
+            // chkDwmFuelBiomass
+            // 
+            this.chkDwmFuelBiomass.AutoSize = true;
+            this.chkDwmFuelBiomass.Location = new System.Drawing.Point(7, 39);
+            this.chkDwmFuelBiomass.Name = "chkDwmFuelBiomass";
+            this.chkDwmFuelBiomass.Size = new System.Drawing.Size(319, 17);
+            this.chkDwmFuelBiomass.TabIndex = 2;
+            this.chkDwmFuelBiomass.Text = "Calculate fuel biomasses with available DWM data (tons/acre)";
+            this.chkDwmFuelBiomass.UseVisualStyleBackColor = true;
+            // 
+            // label4
+            // 
+            this.label4.AutoSize = true;
+            this.label4.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F);
+            this.label4.Location = new System.Drawing.Point(58, 119);
+            this.label4.Name = "label4";
+            this.label4.Size = new System.Drawing.Size(173, 13);
+            this.label4.TabIndex = 99;
+            this.label4.Tag = "txtMinCwdTL";
+            this.label4.Text = "Minimum CWD Transect Length (ft)";
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F);
+            this.label2.Location = new System.Drawing.Point(58, 68);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(200, 13);
+            this.label2.TabIndex = 99;
+            this.label2.Tag = "txtMinSmallFwdTL";
+            this.label2.Text = "Minimum Small FWD Transect Length (ft)";
+            // 
+            // txtMinLargeFwdTL
+            // 
+            this.txtMinLargeFwdTL.Location = new System.Drawing.Point(7, 90);
+            this.txtMinLargeFwdTL.Name = "txtMinLargeFwdTL";
+            this.txtMinLargeFwdTL.Size = new System.Drawing.Size(45, 20);
+            this.txtMinLargeFwdTL.TabIndex = 4;
+            this.txtMinLargeFwdTL.Text = "30";
+            this.txtMinLargeFwdTL.Validating += new System.ComponentModel.CancelEventHandler(this.txtMinLargeFwdTL_Validating);
+            // 
+            // txtMinCwdTL
+            // 
+            this.txtMinCwdTL.Location = new System.Drawing.Point(7, 116);
+            this.txtMinCwdTL.Name = "txtMinCwdTL";
+            this.txtMinCwdTL.Size = new System.Drawing.Size(45, 20);
+            this.txtMinCwdTL.TabIndex = 5;
+            this.txtMinCwdTL.Text = "48";
+            this.txtMinCwdTL.Validating += new System.ComponentModel.CancelEventHandler(this.txtMinCwdTL_Validating);
+            // 
+            // label3
+            // 
+            this.label3.AutoSize = true;
+            this.label3.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F);
+            this.label3.Location = new System.Drawing.Point(58, 93);
+            this.label3.Name = "label3";
+            this.label3.Size = new System.Drawing.Size(202, 13);
+            this.label3.TabIndex = 99;
+            this.label3.Tag = "txtMinLargeFwdTL";
+            this.label3.Text = "Minimum Large FWD Transect Length (ft)";
+            // 
+            // txtMinSmallFwdTL
+            // 
+            this.txtMinSmallFwdTL.Location = new System.Drawing.Point(7, 65);
+            this.txtMinSmallFwdTL.Name = "txtMinSmallFwdTL";
+            this.txtMinSmallFwdTL.Size = new System.Drawing.Size(45, 20);
+            this.txtMinSmallFwdTL.TabIndex = 3;
+            this.txtMinSmallFwdTL.Text = "10";
+            this.txtMinSmallFwdTL.Validating += new System.ComponentModel.CancelEventHandler(this.txtMinSmallFwdTL_Validating);
             // 
             // btnCancel
             // 
-            this.btnCancel.Location = new System.Drawing.Point(568, 567);
+            this.btnCancel.Location = new System.Drawing.Point(567, 540);
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.Size = new System.Drawing.Size(56, 24);
-            this.btnCancel.TabIndex = 48;
+            this.btnCancel.TabIndex = 99;
             this.btnCancel.Text = "Cancel";
             this.btnCancel.Visible = false;
             this.btnCancel.Click += new System.EventHandler(this.btnCancel_Click);
             // 
             // progressBar1
             // 
-            this.progressBar1.Location = new System.Drawing.Point(312, 575);
+            this.progressBar1.Location = new System.Drawing.Point(312, 540);
             this.progressBar1.Name = "progressBar1";
             this.progressBar1.Size = new System.Drawing.Size(240, 8);
-            this.progressBar1.TabIndex = 47;
+            this.progressBar1.TabIndex = 99;
             this.progressBar1.Visible = false;
             // 
             // lblProgress
             // 
-            this.lblProgress.Location = new System.Drawing.Point(312, 591);
+            this.lblProgress.Location = new System.Drawing.Point(312, 556);
             this.lblProgress.Name = "lblProgress";
             this.lblProgress.Size = new System.Drawing.Size(239, 16);
-            this.lblProgress.TabIndex = 46;
+            this.lblProgress.TabIndex = 99;
             this.lblProgress.Text = "lblProgress";
             this.lblProgress.Visible = false;
             // 
             // btnHelp
             // 
             this.btnHelp.ForeColor = System.Drawing.SystemColors.HotTrack;
-            this.btnHelp.Location = new System.Drawing.Point(16, 575);
+            this.btnHelp.Location = new System.Drawing.Point(7, 540);
             this.btnHelp.Name = "btnHelp";
             this.btnHelp.Size = new System.Drawing.Size(96, 32);
-            this.btnHelp.TabIndex = 43;
+            this.btnHelp.TabIndex = 99;
             this.btnHelp.Text = "Help";
             this.btnHelp.Click += new System.EventHandler(this.btnHelp_Click);
             // 
-            // btnRefresh
-            // 
-            this.btnRefresh.Location = new System.Drawing.Point(142, 501);
-            this.btnRefresh.Name = "btnRefresh";
-            this.btnRefresh.Size = new System.Drawing.Size(64, 32);
-            this.btnRefresh.TabIndex = 38;
-            this.btnRefresh.Text = "Refresh";
-            this.btnRefresh.Click += new System.EventHandler(this.btnRefresh_Click);
-            // 
-            // btnClearAll
-            // 
-            this.btnClearAll.Location = new System.Drawing.Point(79, 501);
-            this.btnClearAll.Name = "btnClearAll";
-            this.btnClearAll.Size = new System.Drawing.Size(64, 32);
-            this.btnClearAll.TabIndex = 37;
-            this.btnClearAll.Text = "Clear All";
-            this.btnClearAll.Click += new System.EventHandler(this.btnClearAll_Click);
-            // 
-            // btnChkAll
-            // 
-            this.btnChkAll.Location = new System.Drawing.Point(16, 501);
-            this.btnChkAll.Name = "btnChkAll";
-            this.btnChkAll.Size = new System.Drawing.Size(64, 32);
-            this.btnChkAll.TabIndex = 36;
-            this.btnChkAll.Text = "Check All";
-            this.btnChkAll.Click += new System.EventHandler(this.btnChkAll_Click);
-            // 
             // btnClose
             // 
-            this.btnClose.Location = new System.Drawing.Point(672, 575);
+            this.btnClose.Location = new System.Drawing.Point(678, 536);
             this.btnClose.Name = "btnClose";
             this.btnClose.Size = new System.Drawing.Size(96, 32);
-            this.btnClose.TabIndex = 33;
+            this.btnClose.TabIndex = 6;
             this.btnClose.Text = "Close";
             this.btnClose.Click += new System.EventHandler(this.btnClose_Click);
-            // 
-            // lblVarCnt
-            // 
-            this.lblVarCnt.BackColor = System.Drawing.Color.White;
-            this.lblVarCnt.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lblVarCnt.Location = new System.Drawing.Point(254, 58);
-            this.lblVarCnt.Name = "lblVarCnt";
-            this.lblVarCnt.Size = new System.Drawing.Size(56, 16);
-            this.lblVarCnt.TabIndex = 29;
-            this.lblVarCnt.Text = "0";
-            // 
-            // lblRxCnt
-            // 
-            this.lblRxCnt.BackColor = System.Drawing.Color.White;
-            this.lblRxCnt.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lblRxCnt.Location = new System.Drawing.Point(415, 58);
-            this.lblRxCnt.Name = "lblRxCnt";
-            this.lblRxCnt.Size = new System.Drawing.Size(32, 16);
-            this.lblRxCnt.TabIndex = 27;
-            this.lblRxCnt.Text = "0";
-            // 
-            // lstFvsInput
-            // 
-            this.lstFvsInput.CheckBoxes = true;
-            this.lstFvsInput.GridLines = true;
-            this.lstFvsInput.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.Nonclickable;
-            this.lstFvsInput.HideSelection = false;
-            this.lstFvsInput.Location = new System.Drawing.Point(16, 152);
-            this.lstFvsInput.MultiSelect = false;
-            this.lstFvsInput.Name = "lstFvsInput";
-            this.lstFvsInput.Size = new System.Drawing.Size(752, 344);
-            this.lstFvsInput.TabIndex = 26;
-            this.lstFvsInput.UseCompatibleStateImageBehavior = false;
-            this.lstFvsInput.View = System.Windows.Forms.View.Details;
-            this.lstFvsInput.SelectedIndexChanged += new System.EventHandler(this.lstFvsInput_SelectedIndexChanged);
-            this.lstFvsInput.MouseUp += new System.Windows.Forms.MouseEventHandler(this.lstFvsInput_MouseUp);
             // 
             // lblTitle
             // 
@@ -422,17 +664,24 @@ namespace FIA_Biosum_Manager
             this.lblTitle.Location = new System.Drawing.Point(3, 16);
             this.lblTitle.Name = "lblTitle";
             this.lblTitle.Size = new System.Drawing.Size(778, 32);
-            this.lblTitle.TabIndex = 25;
+            this.lblTitle.TabIndex = 99;
             this.lblTitle.Text = "Create FVS Input";
             // 
             // uc_fvs_input
             // 
             this.Controls.Add(this.groupBox1);
             this.Name = "uc_fvs_input";
-            this.Size = new System.Drawing.Size(784, 616);
+            this.Size = new System.Drawing.Size(784, 585);
             this.Resize += new System.EventHandler(this.uc_fvs_input_Resize);
             this.groupBox1.ResumeLayout(false);
-            this.groupBox1.PerformLayout();
+            this.tabControl1.ResumeLayout(false);
+            this.tabPage2.ResumeLayout(false);
+            this.tabPage2.PerformLayout();
+            this.tabPage1.ResumeLayout(false);
+            this.grpDWMOptions.ResumeLayout(false);
+            this.grpDWMOptions.PerformLayout();
+            this.groupBox2.ResumeLayout(false);
+            this.groupBox2.PerformLayout();
             this.ResumeLayout(false);
 
 		}
@@ -441,59 +690,40 @@ namespace FIA_Biosum_Manager
 		private void uc_fvs_input_Resize(object sender, System.EventArgs e)
 		{
 			this.Resize_Fvs_Input();
+            this.tabControl1_Resize(sender, e);
 		}
+
 		public void Resize_Fvs_Input()
 		{
 			try
 			{
-				this.btnClose.Top = this.groupBox1.Height - this.btnClose.Height - 5;
-				this.btnClose.Left = this.groupBox1.Width - this.btnClose.Width - 5;
-				this.btnHelp.Top = this.btnClose.Top;
-				this.lstFvsInput.Left = 5;
-				this.lstFvsInput.Width = this.Width - 10;
+                progressBar1.Left = (int)(groupBox1.Width * .50) - (int)(progressBar1.Width * .50);
+                progressBar1.Top = btnClose.Top;
 
-				this.lstFvsInput.Height = this.btnClose.Top - this.lstFvsInput.Top - (this.btnExecuteAction.Height * 3);
-				this.btnExecuteAction.Top = this.lstFvsInput.Top + this.lstFvsInput.Height + 2;
-                this.btnExecuteAction.Left = this.lstFvsInput.Width - btnExecuteAction.Width - (lstFvsInput.Left * 2);
-                this.cmbAction.Top = this.btnExecuteAction.Top + (int)(btnExecuteAction.Height * .5) - (int)(cmbAction.Height * .5);
-                this.cmbAction.Left = this.btnExecuteAction.Left - this.cmbAction.Width - 5;
-				
-				this.btnChkAll.Top = this.btnExecuteAction.Top;
-				this.btnClearAll.Top = this.btnExecuteAction.Top;
-				this.btnRefresh.Top = this.btnExecuteAction.Top;
-
-				this.txtDataDir.Width = this.Width - this.txtDataDir.Left - 10;
-
-				this.progressBar1.Left = (int)(this.groupBox1.Width * .50) - (int)(this.progressBar1.Width * .50);
-				this.progressBar1.Top = this.btnClose.Top;
-				
-				
-				if (this.progressBar1.Left < (this.btnHelp.Left + this.btnHelp.Width))
-				{
-					this.progressBar1.Left = this.btnHelp.Left + this.btnHelp.Width;
-				}
-				this.btnCancel.Left = this.progressBar1.Left + this.progressBar1.Width + 2;
-				this.btnCancel.Top = this.progressBar1.Top - (int)(this.btnCancel.Height * .50) + (int)(this.progressBar1.Height * .50);
-				if (this.btnClose.Left < (this.btnCancel.Left + this.btnCancel.Width))
-				{
-					this.btnClose.Left = this.btnCancel.Left + this.btnCancel.Width;
-				}
-				this.lblProgress.Left = this.progressBar1.Left;
-				this.lblProgress.Top = this.progressBar1.Top + this.progressBar1.Height + 2;
-
-
+                if (progressBar1.Left < (btnHelp.Left + btnHelp.Width))
+                {
+                    progressBar1.Left = btnHelp.Left + btnHelp.Width;
+                }
+                btnCancel.Left = progressBar1.Left + progressBar1.Width + 2;
+                btnCancel.Top = progressBar1.Top - (int)(btnCancel.Height * .50) + (int)(progressBar1.Height * .50);
+                if (btnClose.Left < (btnCancel.Left + btnCancel.Width))
+                {
+                    btnClose.Left = btnCancel.Left + btnCancel.Width;
+                }
+                lblProgress.Left = progressBar1.Left;
+                lblProgress.Top = progressBar1.Top + progressBar1.Height + 2;
 			}
 			catch
 			{
 			}
 		}
+
 		public void loadvalues()
 		{
-			
 			this.LoadDataSources();
 			this.populate_listbox();
-
 		}
+
 		private void populate_listbox()
 		{
 			//bool bResult;
@@ -762,6 +992,7 @@ namespace FIA_Biosum_Manager
 			this.Refresh();
 
 		}
+
 		private void LoadDataSources()
 		{
 			this.txtDataDir.Text = this.m_strProjDir + "\\fvs\\data";
@@ -1306,19 +1537,91 @@ namespace FIA_Biosum_Manager
 		{
             ViewScripts();
 		}
+
+        private string[] GetCheckedListBoxItems(CheckedListBox chkListBox){
+            if (chkListBox.InvokeRequired)
+            {
+                var dlg = new GetListBoxItemsDlg(GetCheckedListBoxItems);
+                return chkListBox.Invoke(dlg, chkListBox) as string[];
+            }
+
+            string[] items = (from object item in chkListBox.CheckedItems select item.ToString())
+                .ToArray();
+            return items;
+        }
+
+	    private void ConfigureFvsInput(fvs_input p_fvs)
+	    {
+	        if (chkDwmFuelModel.Checked && chkDwmFuelBiomass.Checked)
+	        {
+	            p_fvs.intDWMOption = (int) fvs_input.m_enumDWMOption.USE_FUEL_MODEL_OR_DWM_DATA;
+	        }
+	        else if (chkDwmFuelModel.Checked)
+	        {
+	            p_fvs.intDWMOption = (int) fvs_input.m_enumDWMOption.USE_FUEL_MODEL_ONLY;
+	        }
+	        else if (chkDwmFuelBiomass.Checked)
+	        {
+	            p_fvs.intDWMOption = (int) fvs_input.m_enumDWMOption.USE_DWM_DATA_ONLY;
+	        }
+	        else
+	        {
+	            p_fvs.intDWMOption = (int) fvs_input.m_enumDWMOption.SKIP_FUEL_MODEL_AND_DWM_DATA;
+	        }
+
+	        p_fvs.strMinSmallFwdTransectLengthTotal =
+	            frmMain.g_oDelegate.GetControlPropertyValue(txtMinSmallFwdTL, "Text", false).ToString();
+	        p_fvs.strMinLargeFwdTransectLengthTotal =
+	            frmMain.g_oDelegate.GetControlPropertyValue(txtMinLargeFwdTL, "Text", false).ToString();
+	        p_fvs.strMinCwdTransectLengthTotal =
+	            frmMain.g_oDelegate.GetControlPropertyValue(txtMinCwdTL, "Text", false).ToString();
+	        bool bFirst = true;
+	        foreach (var item in GetCheckedListBoxItems(chkLstBoxDuffYears))
+	        {
+	            if (bFirst)
+	            {
+	                p_fvs.strDuffExcludedYears += item;
+	                bFirst = false;
+	            }
+	            else
+	            {
+	                p_fvs.strDuffExcludedYears += ", " + item;
+	            }
+	        }
+            bFirst = true;
+	        foreach (var item in GetCheckedListBoxItems(chkLstBoxLitterYears))
+	        {
+	            if (bFirst)
+	            {
+	                p_fvs.strLitterExcludedYears += item;
+	                bFirst = false;
+	            }
+	            else
+	            {
+	                p_fvs.strLitterExcludedYears += ", " + item;
+	            }
+	        }
+	    }
+
 		private void AppendRecords()
 		{
-
+		    m_intError = 0;
 			string strCurVariant="";
 			string strVariant="";
 			string strSavedir = this.m_strProjDir + "\\fvs\\data\\save";
+
 			bAbort=false;
 			try
 			{
-				
-
-
 				fvs_input p_fvsinput = new fvs_input(this.m_strProjDir,this.m_frmTherm);
+
+			    if (p_fvsinput.m_intError != 0)
+			    {
+                    return;
+			    }
+
+                ConfigureFvsInput(p_fvsinput);
+
                 string strDataDir = (string)frmMain.g_oDelegate.GetControlPropertyValue((Control)this.txtDataDir, "Text", false);
                 strDataDir = strDataDir.Trim();
 				for (int x=0;x<=this.lstFvsInput.Items.Count-1;x++)
@@ -1333,7 +1636,6 @@ namespace FIA_Biosum_Manager
 						if (strVariant.Trim().ToUpper() != strCurVariant.Trim().ToUpper())
 						{
 							strCurVariant = strVariant;
-							//p_fvsinput.Start(this.txtInDir.Text.Trim(),strCurVariant);
 							p_fvsinput.Start(strDataDir,strCurVariant);
 						}
 						frmMain.g_oDelegate.SetControlPropertyValue(
@@ -1377,18 +1679,15 @@ namespace FIA_Biosum_Manager
                             frmMain.g_oDelegate.GetControlPropertyValue(
                                     m_frmTherm.progressBar2, "Maximum", false));
 				
-				this.InputFVSRecordsFinished();
 			}
 			catch (System.Threading.ThreadInterruptedException err)
 			{
-
+			    m_intError = -1;
 				MessageBox.Show("Threading Interruption Error " + err.Message.ToString());
 			}
 			catch (System.Threading.ThreadAbortException err)
 			{
-				
-				this.ThreadCleanUp();
-				
+                m_intError = -1;	
 			}
 			catch (Exception err)
 			{
@@ -1399,8 +1698,13 @@ namespace FIA_Biosum_Manager
 					System.Windows.Forms.MessageBoxIcon.Exclamation);
 				this.m_intError=-1;
 			}
-			ThreadCleanUp();
-
+			finally
+			{
+			    if (m_intError == 0)
+			    {
+			        ThreadCleanUp();
+			    }
+			}
 
 		}
 
@@ -1452,6 +1756,7 @@ namespace FIA_Biosum_Manager
 				}
 			}
 		}
+
 		public void StopThread()
 		{
 			this.m_thread.Suspend();
@@ -1467,7 +1772,10 @@ namespace FIA_Biosum_Manager
 					{
 						this.m_frmTherm.lblMsg.Text = "Attempting To Abort Process...Stand By";
 						this.m_frmTherm.lblMsg.Refresh();
-						this.m_thread.Join();
+					    while (m_thread.ThreadState != ThreadState.Aborted)
+					    {
+					        this.m_thread.Join(2000);
+					    }
 					}
 					if (this.m_frmTherm != null)
 					{
@@ -1509,6 +1817,12 @@ namespace FIA_Biosum_Manager
 		{
 			try
 			{
+				if (this.m_frmTherm != null)
+				{
+                    frmMain.g_oDelegate.ExecuteControlMethod(m_frmTherm, "Close");
+                    frmMain.g_oDelegate.ExecuteControlMethod(m_frmTherm, "Dispose");
+                    this.m_frmTherm = null;
+				}
 				
                 frmMain.g_oDelegate.SetControlPropertyValue(cmbAction,"Enabled",true);
                 frmMain.g_oDelegate.SetControlPropertyValue(btnRefresh, "Enabled", true);
@@ -1522,12 +1836,6 @@ namespace FIA_Biosum_Manager
                 frmMain.g_oDelegate.SetControlPropertyValue(lblProgress, "Visible", false);
                 frmMain.g_oDelegate.SetControlPropertyValue(btnCancel, "Visible", false);
                 frmMain.g_oDelegate.SetControlPropertyValue(this, "Enabled", true);
-				if (this.m_frmTherm != null)
-				{
-                    frmMain.g_oDelegate.ExecuteControlMethod(m_frmTherm, "Close");
-                    frmMain.g_oDelegate.ExecuteControlMethod(m_frmTherm, "Dispose");
-                    this.m_frmTherm = null;
-				}
 				this.m_thread = null;
 			}
 			catch
@@ -1588,25 +1896,26 @@ namespace FIA_Biosum_Manager
                 if (System.IO.File.Exists(strDirAndFile))
                 {
                     ado_data_access p_ado = new ado_data_access();
-                    dao_data_access p_dao = new dao_data_access();
                     string strConn = p_ado.getMDBConnString(strDirAndFile, "", "");
 
-                    if (p_dao.TableExists(strDirAndFile, "FVS_StandInit"))
+                    using (var pConn = new System.Data.OleDb.OleDbConnection(strConn)) 
                     {
-                        System.Data.OleDb.OleDbConnection pConn = new System.Data.OleDb.OleDbConnection();
-                        pConn.ConnectionString = strConn;
                         pConn.Open();
-                        stands = (int)m_ado.getSingleDoubleValueFromSQLQuery(pConn,
+                        if (p_ado.TableExist(pConn, "FVS_StandInit"))
+                        {
+                            stands = (int) p_ado.getSingleDoubleValueFromSQLQuery(pConn,
                             "SELECT COUNT(*) as StandInitCount FROM (SELECT DISTINCT Stand_ID FROM FVS_StandInit);",
                             "FVS_StandInit");
-                        trees = (int)m_ado.getSingleDoubleValueFromSQLQuery(pConn,
+                        }
+                        if (p_ado.TableExist(pConn, "FVS_TreeInit"))
+                        {
+                            trees = (int) p_ado.getSingleDoubleValueFromSQLQuery(pConn,
                             "SELECT COUNT(*) as TreeInitCount FROM FVS_TreeInit;",
                             "FVS_TreeInit");
-                        p_ado.CloseConnection(pConn);
-                        pConn.Dispose();
+                        }
+
                     }
                     p_ado = null;
-                    p_dao = null;
                 }
             }
             catch (Exception e)
@@ -2295,8 +2604,107 @@ namespace FIA_Biosum_Manager
         {
             e.Handled = true;
         }
-		
-	
+
+        private void groupBox1_Enter(object sender, EventArgs e)
+        {
+
+        }
+
+        private void txtMinSmallFwdTL_Validating(object sender, CancelEventArgs e)
+        {
+            double temp;
+            if (!double.TryParse(txtMinSmallFwdTL.Text, out temp))
+            {
+                txtMinSmallFwdTL.Text = "10";
+            }
+        }
+
+        private void txtMinLargeFwdTL_Validating(object sender, CancelEventArgs e)
+        {
+            double temp;
+            if (!double.TryParse(txtMinLargeFwdTL.Text, out temp))
+            {
+                txtMinLargeFwdTL.Text = "30";
+            }
+        }
+
+        private void txtMinCwdTL_Validating(object sender, CancelEventArgs e)
+        {
+            double temp;
+            if (!double.TryParse(txtMinCwdTL.Text, out temp))
+            {
+                txtMinCwdTL.Text = "48";
+            }
+        }
+
+
+        private void tabControl1_Resize(object sender, EventArgs e)
+        {
+            tabControl1.Top = this.lblTitle.Bottom + 5;
+            tabControl1.Left = 5;
+            tabControl1.Width = this.Width - 10;
+            tabControl1.Height = this.Height - 100;
+
+            btnClose.Top = groupBox1.Bottom - btnClose.Height - 5;
+            btnClose.Left = tabControl1.Right - btnClose.Width;
+            btnHelp.Left = tabControl1.Left;
+            btnHelp.Top = btnClose.Top;
+
+
+            label1.Left = tabPage2.Left + 5;
+            txtDataDir.Left = label1.Right + 5;
+            txtDataDir.Width = tabPage2.Width - txtDataDir.Left;
+
+            //resize all of the controls on the inside
+            lstFvsInput.Left = tabPage2.Left + 5;
+            lstFvsInput.Width = tabPage2.Width - 10;
+            lstFvsInput.Top = txtDataDir.Bottom + 5;
+            lstFvsInput.Height = tabPage2.Height - txtDataDir.Bottom - 130;
+
+            //btns under lstFvsInput position based on tabControl perimeter
+            btnExecuteAction.Top = lstFvsInput.Bottom + 5;
+            btnExecuteAction.Left = lstFvsInput.Right - btnExecuteAction.Width;
+
+            cmbAction.Top = btnExecuteAction.Top + (int) (btnExecuteAction.Height * .5) - (int) (cmbAction.Height * .5);
+            cmbAction.Left = btnExecuteAction.Left - cmbAction.Width - 5;
+
+            btnChkAll.Top = btnExecuteAction.Top;
+            btnChkAll.Left = lstFvsInput.Left;
+            btnClearAll.Top = btnExecuteAction.Top;
+            btnClearAll.Left = btnChkAll.Right + 5;
+            btnRefresh.Top = btnExecuteAction.Top;
+            btnRefresh.Left = btnClearAll.Right + 5;
+        }
+
+	    private void tabControl1_TabIndexChanged(object sender, EventArgs e)
+        {
+            tabPage1.Refresh();
+            tabPage2.Refresh();
+        }
+
+        private void linkLabelFuelModel_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+        {
+            try
+            {
+                VisitLink();
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show("Unable to open link that was clicked.");
+            }  
+        }
+
+	    private void VisitLink()
+	    {
+	        // Change the color of the link text by setting LinkVisited   
+	        // to true.  
+	        linkLabelFuelModel.LinkVisited = true;
+	        //Call the Process.Start method to open the default browser   
+	        //with a URL:  
+            System.Diagnostics.Process.Start("https://www.fs.usda.gov/treesearch/pubs/download/9521.pdf");
+	    }
+
+       
 
 	}
 }

--- a/src/uc_fvs_output.cs
+++ b/src/uc_fvs_output.cs
@@ -4905,7 +4905,6 @@ namespace FIA_Biosum_Manager
                                                        "a.fvs_tree_id=b.fvs_tree_id " +
                                                     "SET a.volcfnet=b.tcuft " +
                                                     "WHERE a.volcfnet IS NULL;";
-                                    oAdo.SqlNonQuery(oConn, oAdo.m_strSQL);
                                     if (m_bDebug && frmMain.g_intDebugLevel > 2)
                                         this.WriteText(m_strDebugFile, "START: " + System.DateTime.Now.ToString() + "\r\n" + oAdo.m_strSQL + "\r\n");
                                     oAdo.SqlNonQuery(oConn, oAdo.m_strSQL);

--- a/src/uc_plot_input.cs
+++ b/src/uc_plot_input.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.ComponentModel;
 using System.Drawing;
 using System.Data;
+using System.Data.OleDb;
 using System.Windows.Forms;
 using System.Xml;
 using System.Threading;
@@ -97,7 +98,14 @@ namespace FIA_Biosum_Manager
 		private string m_strPopStratumTable;
         private string m_strBiosumPopStratumAdjustmentFactorsTable;
         private string m_strTreeMacroPlotBreakPointDiaTable;
+        private string m_strDwmCwdTable = frmMain.g_oTables.m_oFIAPlot.DefaultDWMCoarseWoodyDebrisName;
+        private string m_strDwmFwdTable = frmMain.g_oTables.m_oFIAPlot.DefaultDWMFineWoodyDebrisName;
+        private string m_strDwmDuffLitterTable = frmMain.g_oTables.m_oFIAPlot.DefaultDWMDuffLitterFuelName;
+        private string m_strDwmTransectSegmentTable = frmMain.g_oTables.m_oFIAPlot.DefaultDWMTransectSegmentName;
+        //TODO: GRM
+
 		private string m_strSQL;
+
 		private FIA_Biosum_Manager.frmTherm m_frmTherm;
 		private string m_strPlotIdList="";
 		private System.Windows.Forms.GroupBox groupBox7;
@@ -137,6 +145,10 @@ namespace FIA_Biosum_Manager
 		private int m_intAddedCondRows=0;
 		private int m_intAddedTreeRows=0;
 		private int m_intAddedSiteTreeRows=0;
+	    private int m_intAddedDwmCwdRows=0;
+	    private int m_intAddedDwmFwdRows=0;
+	    private int m_intAddedDwmDuffLitterRows=0;
+	    private int m_intAddedDwmTransectSegmentRows=0;
         private int m_intAddedTreeRegionalBiomassRows = 0;
 		private System.Windows.Forms.GroupBox grpboxFIADBInv;
 		private System.Windows.Forms.Button btnFIADBInvAppend;
@@ -188,13 +200,16 @@ namespace FIA_Biosum_Manager
         private env m_oEnv;
         private Help m_oHelp;
         private string m_xpsFile = Help.DefaultDatabaseXPSFile;
+        private CheckBox chkDwmImport;
 		
 
 		/// <summary> 
 		/// Required designer variable.
 		/// </summary>
 		private System.ComponentModel.Container components = null;
-        public frmDialog ReferenceFormDialog
+
+
+	    public frmDialog ReferenceFormDialog
         {
             set { _frmDialog = value; }
             get { return _frmDialog; }
@@ -291,6 +306,7 @@ namespace FIA_Biosum_Manager
             this.btnFilterNext = new System.Windows.Forms.Button();
             this.btnFilterCancel = new System.Windows.Forms.Button();
             this.groupBox7 = new System.Windows.Forms.GroupBox();
+            this.chkDwmImport = new System.Windows.Forms.CheckBox();
             this.label2 = new System.Windows.Forms.Label();
             this.cmbCondPropPercent = new System.Windows.Forms.ComboBox();
             this.label1 = new System.Windows.Forms.Label();
@@ -932,6 +948,7 @@ namespace FIA_Biosum_Manager
             // 
             // groupBox7
             // 
+            this.groupBox7.Controls.Add(this.chkDwmImport);
             this.groupBox7.Controls.Add(this.label2);
             this.groupBox7.Controls.Add(this.cmbCondPropPercent);
             this.groupBox7.Controls.Add(this.label1);
@@ -942,25 +959,35 @@ namespace FIA_Biosum_Manager
             this.groupBox7.Controls.Add(this.rdoFilterByFile);
             this.groupBox7.Controls.Add(this.rdoFilterByMenu);
             this.groupBox7.Controls.Add(this.rdoFilterNone);
-            this.groupBox7.Location = new System.Drawing.Point(85, 59);
+            this.groupBox7.Location = new System.Drawing.Point(85, 19);
             this.groupBox7.Name = "groupBox7";
-            this.groupBox7.Size = new System.Drawing.Size(519, 249);
+            this.groupBox7.Size = new System.Drawing.Size(519, 289);
             this.groupBox7.TabIndex = 1;
             this.groupBox7.TabStop = false;
+            // 
+            // chkDwmImport
+            // 
+            this.chkDwmImport.AutoSize = true;
+            this.chkDwmImport.Location = new System.Drawing.Point(61, 189);
+            this.chkDwmImport.Name = "chkDwmImport";
+            this.chkDwmImport.Size = new System.Drawing.Size(184, 17);
+            this.chkDwmImport.TabIndex = 10;
+            this.chkDwmImport.Text = "Use Down Woody Materials Data";
+            this.chkDwmImport.UseVisualStyleBackColor = true;
             // 
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(270, 217);
+            this.label2.Location = new System.Drawing.Point(58, 241);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(191, 13);
+            this.label2.Size = new System.Drawing.Size(339, 13);
             this.label2.TabIndex = 9;
-            this.label2.Text = "to change from forested to nonsampled";
+            this.label2.Text = "percent, condition status will be changed from forested to nonsampled.";
             // 
             // cmbCondPropPercent
             // 
             this.cmbCondPropPercent.FormattingEnabled = true;
-            this.cmbCondPropPercent.Location = new System.Drawing.Point(200, 214);
+            this.cmbCondPropPercent.Location = new System.Drawing.Point(376, 214);
             this.cmbCondPropPercent.Name = "cmbCondPropPercent";
             this.cmbCondPropPercent.Size = new System.Drawing.Size(52, 21);
             this.cmbCondPropPercent.TabIndex = 8;
@@ -969,16 +996,14 @@ namespace FIA_Biosum_Manager
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(6, 217);
+            this.label1.Location = new System.Drawing.Point(58, 217);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(188, 13);
+            this.label1.Size = new System.Drawing.Size(302, 13);
             this.label1.TabIndex = 7;
-            this.label1.Text = "Condition proportion percent  less than";
+            this.label1.Text = "When a forested condition has a condition proportion less than";
             // 
             // chkNonForested
             // 
-            this.chkNonForested.Checked = true;
-            this.chkNonForested.CheckState = System.Windows.Forms.CheckState.Checked;
             this.chkNonForested.Location = new System.Drawing.Point(133, 167);
             this.chkNonForested.Name = "chkNonForested";
             this.chkNonForested.Size = new System.Drawing.Size(112, 16);
@@ -1008,7 +1033,7 @@ namespace FIA_Biosum_Manager
             // txtFilterByFile
             // 
             this.txtFilterByFile.Enabled = false;
-            this.txtFilterByFile.Location = new System.Drawing.Point(64, 132);
+            this.txtFilterByFile.Location = new System.Drawing.Point(61, 134);
             this.txtFilterByFile.Name = "txtFilterByFile";
             this.txtFilterByFile.Size = new System.Drawing.Size(328, 20);
             this.txtFilterByFile.TabIndex = 3;
@@ -2099,6 +2124,7 @@ namespace FIA_Biosum_Manager
                     
                     //destroy the object and release it from memory
                     oDao.m_DaoWorkspace.Close();
+                    oDao.m_DaoWorkspace = null;
                     oDao = null;
 
                      m_intError = m_ado.m_intError;
@@ -2237,7 +2263,6 @@ namespace FIA_Biosum_Manager
             string str2 = "";
 
 			string strSourceTableLink="";
-			//string strMsg="";
             string strFIADBDbFile = "";
             string strSourceTableName = "";
             string strDestTableLinkName = "";
@@ -2249,9 +2274,7 @@ namespace FIA_Biosum_Manager
 
 		    this.m_intError=0;		
 			
-
 			//-----------PREPARATION FOR ADDING PLOT RECORDS---------//
-
             try
             {
                 //instatiate the oledb data access class
@@ -2340,6 +2363,7 @@ namespace FIA_Biosum_Manager
 
                 //destroy the object and release it from memory
                 p_dao1.m_DaoWorkspace.Close();
+                p_dao1.m_DaoWorkspace = null;
                 p_dao1 = null;
 
 
@@ -2353,37 +2377,30 @@ namespace FIA_Biosum_Manager
                 System.Data.DataTable dtFIADBCondSchema = new DataTable();
                 System.Data.DataTable dtFIADBTreeSchema = new DataTable();
                 System.Data.DataTable dtFIADBSiteTreeSchema = new DataTable();
-               
 
-                    //get an ado connection string for the temp mdb file
-                    this.m_strTempMDBFileConn = this.m_ado.getMDBConnString(this.m_strTempMDBFile, "", "");
+                //get an ado connection string for the temp mdb file
+                this.m_strTempMDBFileConn = this.m_ado.getMDBConnString(this.m_strTempMDBFile, "", "");
 
+                //create a new connection to the temp MDB file
+                this.m_connTempMDBFile = new System.Data.OleDb.OleDbConnection();
 
-                    //create a new connection to the temp MDB file
-                    this.m_connTempMDBFile = new System.Data.OleDb.OleDbConnection();
+                //open the connection to the temp mdb file 
+                this.m_ado.OpenConnection(this.m_strTempMDBFileConn, ref this.m_connTempMDBFile);
 
-                    //open the connection to the temp mdb file 
-                    this.m_ado.OpenConnection(this.m_strTempMDBFileConn, ref this.m_connTempMDBFile);
+                //Before processing new plot information, delete any records that were not completely processed
+                DeleteFromTablesWhereFilter(m_ado, this.m_strPlotTable, " WHERE biosum_status_cd=9 OR LEN(biosum_plot_id)=0;");
+                DeleteFromTablesWhereFilter(m_ado, new string[]
+                {
+                    m_strCondTable, m_strTreeTable, m_strSiteTreeTable,
+                }, " WHERE biosum_status_cd=9;");
+                if (m_strTreeRegionalBiomassTable.Trim().Length > 0 &&
+                    m_ado.TableExist(m_connTempMDBFile, m_strTreeRegionalBiomassTable))
+                {
+                    DeleteFromTablesWhereFilter(m_ado, this.m_strTreeRegionalBiomassTable, " WHERE biosum_status_cd=9;");
+                }
 
-
-
-                    m_ado.m_strSQL = "DELETE FROM " + this.m_strPlotTable + " WHERE biosum_status_cd=9 OR LEN(biosum_plot_id)=0;";
-                    m_ado.SqlNonQuery(m_connTempMDBFile, m_ado.m_strSQL);
-                    m_ado.m_strSQL = "DELETE FROM " + this.m_strCondTable + " WHERE biosum_status_cd=9;";
-                    m_ado.SqlNonQuery(m_connTempMDBFile, m_ado.m_strSQL);
-                    m_ado.m_strSQL = "DELETE FROM " + this.m_strTreeTable + " WHERE biosum_status_cd=9;";
-                    m_ado.SqlNonQuery(m_connTempMDBFile, m_ado.m_strSQL);
-                    if (m_strTreeRegionalBiomassTable.Trim().Length > 0 && m_ado.TableExist(m_connTempMDBFile,m_strTreeRegionalBiomassTable))
-                    {
-                        m_ado.m_strSQL = "DELETE FROM " + this.m_strTreeRegionalBiomassTable + " WHERE biosum_status_cd=9;";
-                        m_ado.SqlNonQuery(m_connTempMDBFile, m_ado.m_strSQL);
-                    }
-                    m_ado.m_strSQL = "DELETE FROM " + this.m_strSiteTreeTable + " WHERE biosum_status_cd=9;";
-                    m_ado.SqlNonQuery(m_connTempMDBFile, m_ado.m_strSQL);
-
-                    if (m_intError == 0) m_intError = m_ado.m_intError;
-
-
+                if (m_intError == 0)
+                    m_intError = m_ado.m_intError;
 
                 if (this.m_intError == 0 && !GetBooleanValue((System.Windows.Forms.Control)m_frmTherm,"AbortProcess"))
                 {
@@ -2397,45 +2414,23 @@ namespace FIA_Biosum_Manager
                     dtCondSchema = this.m_ado.getTableSchema(this.m_connTempMDBFile, "select * from " + this.m_strCondTable);
                     dtTreeSchema = this.m_ado.getTableSchema(this.m_connTempMDBFile, "select * from " + this.m_strTreeTable);
                     dtSiteTreeSchema = this.m_ado.getTableSchema(this.m_connTempMDBFile, "select * from " + this.m_strSiteTreeTable);
+
                     //get the fiadb table structures
                     dtFIADBPlotSchema = this.m_ado.getTableSchema(this.m_connTempMDBFile, "select * from fiadb_plot_input");
                     dtFIADBCondSchema = this.m_ado.getTableSchema(this.m_connTempMDBFile, "select * from fiadb_cond_input");
                     dtFIADBTreeSchema = this.m_ado.getTableSchema(this.m_connTempMDBFile, "select * from fiadb_tree_input");
                     dtFIADBSiteTreeSchema = this.m_ado.getTableSchema(this.m_connTempMDBFile, "select * from fiadb_site_tree_input");
+
                     m_intError = m_ado.m_intError;
                 }
 
                 if (this.m_intError == 0 && !GetBooleanValue((System.Windows.Forms.Control)m_frmTherm,"AbortProcess"))
                 {
-                   
-
-
                     //-------------PLOT TABLE----------------//
                     strSourceTableLink = "fiadb_plot_input";
+                    //build field list string to insert sql by matching columns in thebiosum and fiadb plot tables
+                    strFields = CreateStrFieldsFromDataTables(dtPlotSchema, dtFIADBPlotSchema);
 
-                    //build field list string to insert sql by matching 
-                    //up the column names in the biosum plot table and the fiadb plot table
-                    strFields = "";
-                    for (x = 0; x <= dtPlotSchema.Rows.Count - 1; x++)
-                    {
-                        strCol = dtPlotSchema.Rows[x]["columnname"].ToString().Trim();
-                        //see if there is an equivalent FIADB column
-                        for (y = 0; y <= dtFIADBPlotSchema.Rows.Count - 1; y++)
-                        {
-                            if (strCol.Trim().ToUpper() == dtFIADBPlotSchema.Rows[y]["columnname"].ToString().ToUpper())
-                            {
-                                if (strFields.Trim().Length == 0)
-                                {
-                                    strFields = strCol;
-                                }
-                                else
-                                {
-                                    strFields += "," + strCol;
-                                }
-                                break;
-                            }
-                        }
-                    }
                     SetLabelValue(m_frmTherm.lblMsg,"Text","Plot Table: Insert New Plot Records");
                     if (Checked(rdoFilterByFile) == true && m_strPlotIdList.Trim().Length > 0 &&
                         !GetBooleanValue((System.Windows.Forms.Control)m_frmTherm, "AbortProcess"))
@@ -2460,7 +2455,6 @@ namespace FIA_Biosum_Manager
                             "p.cn=ppsa.plt_cn AND " +
                             "ppsa.rscd = " + this.m_strCurrFIADBRsCd + " AND " +
                             "ppsa.evalid = " + this.m_strCurrFIADBEvalId;
-
                     }
                     else
                     {
@@ -2474,6 +2468,7 @@ namespace FIA_Biosum_Manager
                             " WHERE ppsa.rscd = " + this.m_strCurrFIADBRsCd + " AND " +
                             "ppsa.evalid = " + this.m_strCurrFIADBEvalId;
                     }
+
                     if (Checked(rdoFilterNone))
                     {
                         //forested/nonforested filters
@@ -2531,11 +2526,11 @@ namespace FIA_Biosum_Manager
                     this.m_ado.SqlNonQuery(this.m_connTempMDBFile, this.m_ado.m_strSQL);
                     m_intError = m_ado.m_intError;
                 }
+
                 if (m_intError == 0 && !GetBooleanValue((System.Windows.Forms.Control)m_frmTherm, "AbortProcess"))
                 {
                     SetThermValue(m_frmTherm.progressBar1, "Value", 30);
                     SetLabelValue(m_frmTherm.lblMsg,"Text","Plot Table: Update Biosum_Plot_Id Column");
-                    
                     System.Data.OleDb.OleDbTransaction p_transTempPlot = this.m_connTempMDBFile.BeginTransaction();
 
                     //update the biosum_plot_id column
@@ -2569,19 +2564,19 @@ namespace FIA_Biosum_Manager
                     m_ado.m_OleDbDataAdapter = null;
                     m_intError = m_ado.m_intError;
                 }
+
                 if (m_intError == 0 && !GetBooleanValue((System.Windows.Forms.Control)m_frmTherm, "AbortProcess"))
                 {
                     SetThermValue(m_frmTherm.progressBar1, "Value", 40);
-                    
                     //insert the new plot records into the plot table
                     m_ado.m_strSQL = "INSERT INTO " + this.m_strPlotTable + " (biosum_plot_id,biosum_status_cd," + strFields + ") " +
                         "SELECT TRIM(biosum_plot_id),biosum_status_cd," + strFields + " FROM tempplot";
                     this.m_ado.SqlNonQuery(this.m_connTempMDBFile, this.m_ado.m_strSQL);
                     m_intError = m_ado.m_intError;
                 }
+
                 if (m_intError == 0 && !GetBooleanValue((System.Windows.Forms.Control)m_frmTherm, "AbortProcess"))
                 {
-
                     //initialize columns
                     m_ado.m_strSQL = "UPDATE " + this.m_strPlotTable + " " +
                         "SET gis_protected_area_yn='N'," +
@@ -2593,9 +2588,9 @@ namespace FIA_Biosum_Manager
                     this.m_ado.SqlNonQuery(this.m_connTempMDBFile, this.m_ado.m_strSQL);
                     m_intError = m_ado.m_intError;
                 }
+
                 if (m_intError == 0 && !GetBooleanValue((System.Windows.Forms.Control)m_frmTherm, "AbortProcess"))
                 {
-
                     //create plot column update work table
                     this.m_strSQL = "SELECT biosum_plot_id, statecd as cond_ttl " +
                         "INTO plot_column_updates_work_table FROM " + this.m_strPlotTable.Trim() + " WHERE 1=2;";
@@ -2608,37 +2603,10 @@ namespace FIA_Biosum_Manager
                 {
                     SetThermValue(m_frmTherm.progressBar1,"Value",40);
                     SetThermValue(m_frmTherm.progressBar2,"Value",20);
-
-                    
                     //-------------CONDITION TABLE----------------//
                     strSourceTableLink = "fiadb_cond_input";
-
-
-
-                    //build field list string to insert sql by matching 
-                    //up the column names in the biosum plot table and the fiadb plot table
-                    strFields = "";
-                    for (x = 0; x <= dtCondSchema.Rows.Count - 1; x++)
-                    {
-                        strCol = dtCondSchema.Rows[x]["columnname"].ToString().Trim();
-                        //see if there is an equivalent FIADB column
-                        for (y = 0; y <= dtFIADBCondSchema.Rows.Count - 1; y++)
-                        {
-                            if (strCol.Trim().ToUpper() == dtFIADBCondSchema.Rows[y]["columnname"].ToString().ToUpper())
-                            {
-                                if (strFields.Trim().Length == 0)
-                                {
-                                    strFields = strCol;
-                                }
-                                else
-                                {
-                                    strFields += "," + strCol;
-                                }
-                                break;
-                            }
-                        }
-                    }
-
+                    //build field list string to insert sql by matching FIADB and BioSum Cond columns
+                    strFields = CreateStrFieldsFromDataTables(dtFIADBCondSchema, dtCondSchema);
                     /********************************************************
                      **create condition input insert command
                      ********************************************************/
@@ -2650,10 +2618,10 @@ namespace FIA_Biosum_Manager
                     this.m_ado.SqlNonQuery(this.m_connTempMDBFile, this.m_ado.m_strSQL);
                     m_intError = m_ado.m_intError;
                 }
+
                 if (m_intError == 0 && !GetBooleanValue((System.Windows.Forms.Control)m_frmTherm, "AbortProcess"))
                 {
                     SetThermValue(m_frmTherm.progressBar1, "Value", 60);
-
                     //insert the new condition records into the condition table
                     m_ado.m_strSQL = "INSERT INTO " + this.m_strCondTable + " (biosum_plot_id,biosum_cond_id,biosum_status_cd," + strFields + ") " +
                         "SELECT TRIM(biosum_plot_id),TRIM(biosum_cond_id),biosum_status_cd," + strFields + " FROM tempcond";
@@ -2665,7 +2633,6 @@ namespace FIA_Biosum_Manager
                         "SET d.landclcd = s.cond_status_cd";
                     if (m_ado.m_intError == 0)
                         this.m_ado.SqlNonQuery(this.m_connTempMDBFile, this.m_ado.m_strSQL);
-
 
                     //create cond column work table
                     this.m_strSQL = "SELECT biosum_cond_id, qmd_tot_cm,hwd_qmd_tot_cm," +
@@ -2680,54 +2647,27 @@ namespace FIA_Biosum_Manager
                         m_ado.SqlNonQuery(this.m_connTempMDBFile, this.m_strSQL);
                     m_intError = m_ado.m_intError;
                 }
+
                 if (m_intError == 0 && !GetBooleanValue((System.Windows.Forms.Control)m_frmTherm, "AbortProcess"))
                 {
                     SetThermValue(m_frmTherm.progressBar1, "Value", 65);
                     SetThermValue(m_frmTherm.progressBar2, "Value", 40);
-                    
-
-
-
                     //-------------TREE TABLE----------------//
                     strSourceTableLink = "fiadb_tree_input";
-
-
-                    //build field list string to insert sql by matching 
-                    //up the column names in the biosum plot table and the fiadb plot table
-                    strFields = "";
-                    for (x = 0; x <= dtTreeSchema.Rows.Count - 1; x++)
-                    {
-                        strCol = dtTreeSchema.Rows[x]["columnname"].ToString().Trim();
-                        //see if there is an equivalent FIADB column
-                        for (y = 0; y <= dtFIADBTreeSchema.Rows.Count - 1; y++)
-                        {
-                            if (strCol.Trim().ToUpper() == dtFIADBTreeSchema.Rows[y]["columnname"].ToString().ToUpper())
-                            {
-                                if (strFields.Trim().Length == 0)
-                                {
-                                    strFields = strCol;
-                                }
-                                else
-                                {
-                                    strFields += "," + strCol;
-                                }
-                                break;
-                            }
-                        }
-                    }
-
+                    //build field list string to insert sql by matching FIADB and BioSum Tree columns
+                    strFields = CreateStrFieldsFromDataTables(dtFIADBTreeSchema, dtTreeSchema);
                     /********************************************************
                      **create tree input insert command
                      ********************************************************/
                     //check the user defined filters
                     SetLabelValue(m_frmTherm.lblMsg,"Text","Tree Table: Insert New  Records");
-
                     this.m_ado.m_strSQL = "SELECT TRIM(p.biosum_plot_id) + TRIM(CSTR(t.condid)) AS biosum_cond_id,9 AS biosum_status_cd,t.* INTO temptree FROM " + strSourceTableLink + " t " +
                         " INNER JOIN " + this.m_strPlotTable + " p ON t.plt_cn=p.cn " +
                         " WHERE p.biosum_status_cd=9 AND t.statuscd<>0;";
                     this.m_ado.SqlNonQuery(this.m_connTempMDBFile, this.m_ado.m_strSQL);
                     m_intError = m_ado.m_intError;
                 }
+
                 if (m_intError == 0 && !GetBooleanValue((System.Windows.Forms.Control)m_frmTherm, "AbortProcess"))
                 {
                     SetThermValue(m_frmTherm.progressBar1, "Value", 75);
@@ -2750,10 +2690,10 @@ namespace FIA_Biosum_Manager
                         m_intError = m_ado.m_intError;
                     }
                 }
+
                 if (m_intError == 0 && !GetBooleanValue((System.Windows.Forms.Control)m_frmTherm, "AbortProcess"))
                 {
                     SetThermValue(m_frmTherm.progressBar1, "Value", 80);
-
                     //update the cullbf column
                     this.m_ado.m_strSQL = "UPDATE " + this.m_strTreeTable + " " +
                         "SET cullbf=IIF(cullbf IS NULL," +
@@ -2764,37 +2704,13 @@ namespace FIA_Biosum_Manager
                     this.m_ado.SqlNonQuery(this.m_connTempMDBFile, this.m_ado.m_strSQL);
                     m_intError = m_ado.m_intError;
                 }
+
                 if (m_intError == 0 && !GetBooleanValue((System.Windows.Forms.Control)m_frmTherm, "AbortProcess"))
                 {
-
                     //-------------SITE TREE TABLE----------------//
                     strSourceTableLink = "fiadb_site_tree_input";
-
-
-                    //build field list string to insert sql by matching 
-                    //up the column names in the biosum plot table and the fiadb plot table
-                    strFields = "";
-                    for (x = 0; x <= dtSiteTreeSchema.Rows.Count - 1; x++)
-                    {
-                        strCol = dtSiteTreeSchema.Rows[x]["columnname"].ToString().Trim();
-                        //see if there is an equivalent FIADB column
-                        for (y = 0; y <= dtFIADBSiteTreeSchema.Rows.Count - 1; y++)
-                        {
-                            if (strCol.Trim().ToUpper() == dtFIADBSiteTreeSchema.Rows[y]["columnname"].ToString().ToUpper())
-                            {
-                                if (strFields.Trim().Length == 0)
-                                {
-                                    strFields = strCol;
-                                }
-                                else
-                                {
-                                    strFields += "," + strCol;
-                                }
-                                break;
-                            }
-                        }
-                    }
-
+                    //build field list string to insert sql by matching biosum fiadb SiteTree table
+                    strFields = CreateStrFieldsFromDataTables(dtFIADBSiteTreeSchema, dtSiteTreeSchema);
                     /********************************************************
                      **create site tree input insert command
                      ********************************************************/
@@ -2806,11 +2722,10 @@ namespace FIA_Biosum_Manager
                     this.m_ado.SqlNonQuery(this.m_connTempMDBFile, this.m_ado.m_strSQL);
                     m_intError = m_ado.m_intError;
                 }
+
                 if (m_intError == 0 && !GetBooleanValue((System.Windows.Forms.Control)m_frmTherm, "AbortProcess"))
                 {
                     SetThermValue(m_frmTherm.progressBar1, "Value", 80);
-                    
-
                     //insert the new condition records into the condition table
                     m_ado.m_strSQL = "INSERT INTO " + this.m_strSiteTreeTable + " (biosum_plot_id,biosum_status_cd," + strFields + ") " +
                         "SELECT TRIM(biosum_plot_id),biosum_status_cd," + strFields + " FROM tempsitetree";
@@ -2822,58 +2737,118 @@ namespace FIA_Biosum_Manager
                 if (m_intError == 0 && !GetBooleanValue((System.Windows.Forms.Control)m_frmTherm, "AbortProcess"))
                 {
                     SetThermValue(m_frmTherm.progressBar1, "Value", 100);
-                    SetThermValue(m_frmTherm.progressBar2, "Value", 80);
+                    SetThermValue(m_frmTherm.progressBar2, "Value", 60);
                     this.UpdateColumns(m_ado);
                     m_intError = m_ado.m_intError;
                 }
+
+                if (m_intError == 0 && Checked(chkDwmImport) &&
+                    !GetBooleanValue((System.Windows.Forms.Control) m_frmTherm, "AbortProcess"))
+                {
+                    SetThermValue(m_frmTherm.progressBar1, "Value",
+                        GetThermValue(m_frmTherm.progressBar1, "Maximum"));
+                    SetThermValue(m_frmTherm.progressBar2, "Value", 80);
+                    UpdateColumnsDownWoodyMaterials(m_ado);
+                    m_intError = m_ado.m_intError;
+                }
+
                 if (this.m_intError == 0 && !GetBooleanValue((System.Windows.Forms.Control)m_frmTherm, "AbortProcess"))
                 {
-                    m_intAddedPlotRows = (int)this.m_ado.getRecordCount(this.m_connTempMDBFile, "select count(*) from " + this.m_strPlotTable + " WHERE biosum_status_cd=9", m_strPlotTable);
-                    m_intAddedCondRows = (int)this.m_ado.getRecordCount(this.m_connTempMDBFile, "select count(*) from " + this.m_strCondTable + " WHERE biosum_status_cd=9", m_strCondTable);
-                    m_intAddedTreeRows = (int)this.m_ado.getRecordCount(this.m_connTempMDBFile, "select count(*) from " + this.m_strTreeTable + " WHERE biosum_status_cd=9", m_strTreeTable);
-
-                    if (m_strTreeRegionalBiomassTable.Trim().Length > 0 && m_ado.TableExist(m_connTempMDBFile, m_strTreeRegionalBiomassTable))
-                        m_intAddedTreeRegionalBiomassRows = (int)this.m_ado.getRecordCount(this.m_connTempMDBFile, "select count(*) from " + this.m_strTreeRegionalBiomassTable + " WHERE biosum_status_cd=9", m_strTreeRegionalBiomassTable);
-                    else
-                        m_intAddedTreeRegionalBiomassRows = 0;
-
-                    m_intAddedSiteTreeRows = (int)this.m_ado.getRecordCount(this.m_connTempMDBFile, "select count(*) from " + this.m_strSiteTreeTable + " WHERE biosum_status_cd=9", m_strSiteTreeTable);
-
-                    this.m_strSQL = " UPDATE " + this.m_strPlotTable + " SET biosum_status_cd=1 WHERE biosum_status_cd = 9";
-                    this.m_ado.SqlNonQuery(this.m_connTempMDBFile, this.m_strSQL);
-                    this.m_strSQL = " UPDATE " + this.m_strCondTable + " SET biosum_status_cd=1 WHERE biosum_status_cd = 9;";
-                    this.m_ado.SqlNonQuery(this.m_connTempMDBFile, this.m_strSQL);
-                    this.m_strSQL = " UPDATE " + this.m_strTreeTable + " SET biosum_status_cd=1 WHERE biosum_status_cd = 9;";
-                    this.m_ado.SqlNonQuery(this.m_connTempMDBFile, this.m_strSQL);
-                    this.m_strSQL = " UPDATE " + this.m_strPopEvalTable + " SET biosum_status_cd=1 WHERE biosum_status_cd = 9;";
-                    this.m_ado.SqlNonQuery(this.m_connTempMDBFile, this.m_strSQL);
-                    if (m_strTreeRegionalBiomassTable.Trim().Length > 0 && m_ado.TableExist(m_connTempMDBFile, m_strTreeRegionalBiomassTable))
+                    //Record counts associated with imported plots for each table
+                    m_intAddedPlotRows = (int) m_ado.getRecordCount(m_connTempMDBFile,
+                        "select count(*) from " + m_strPlotTable + " WHERE biosum_status_cd=9", m_strPlotTable);
+                    m_intAddedCondRows = (int) m_ado.getRecordCount(m_connTempMDBFile,
+                        "select count(*) from " + m_strCondTable + " WHERE biosum_status_cd=9", m_strCondTable);
+                    m_intAddedTreeRows = (int) m_ado.getRecordCount(m_connTempMDBFile,
+                        "select count(*) from " + m_strTreeTable + " WHERE biosum_status_cd=9", m_strTreeTable);
+                    if (m_strTreeRegionalBiomassTable.Trim().Length > 0 &&
+                        m_ado.TableExist(m_connTempMDBFile, m_strTreeRegionalBiomassTable))
                     {
-                        this.m_strSQL = " UPDATE " + this.m_strTreeRegionalBiomassTable + " SET biosum_status_cd=1 WHERE biosum_status_cd = 9;";
+                        m_intAddedTreeRegionalBiomassRows = (int) m_ado.getRecordCount(m_connTempMDBFile,
+                            "select count(*) from " + m_strTreeRegionalBiomassTable + " WHERE biosum_status_cd=9",
+                            m_strTreeRegionalBiomassTable);
+                    }
+                    else
+                    {
+                        m_intAddedTreeRegionalBiomassRows = 0;
+                    }
+
+                    m_intAddedSiteTreeRows = (int) m_ado.getRecordCount(m_connTempMDBFile,
+                        "select count(*) from " + m_strSiteTreeTable + " WHERE biosum_status_cd=9", m_strSiteTreeTable);
+
+                    if(Checked(chkDwmImport)) 
+                    {
+                        m_intAddedDwmCwdRows = (int) m_ado.getRecordCount(m_connTempMDBFile,
+                            "select count(*) from " + m_strDwmCwdTable + " WHERE biosum_status_cd=9", m_strDwmCwdTable);
+                        m_intAddedDwmFwdRows = (int) m_ado.getRecordCount(m_connTempMDBFile,
+                            "select count(*) from " + m_strDwmFwdTable + " WHERE biosum_status_cd=9", m_strDwmFwdTable);
+                        m_intAddedDwmDuffLitterRows = (int) m_ado.getRecordCount(m_connTempMDBFile,
+                            "select count(*) from " + m_strDwmDuffLitterTable + " WHERE biosum_status_cd=9",
+                            m_strDwmDuffLitterTable);
+                        m_intAddedDwmTransectSegmentRows = (int) m_ado.getRecordCount(m_connTempMDBFile,
+                            "select count(*) from " + m_strDwmTransectSegmentTable + " WHERE biosum_status_cd=9",
+                            m_strDwmTransectSegmentTable);
+                    }
+
+                    //Successfully imported and updated plot data. Set biosum_status_cd to 1
+                    foreach (string table in new string[]
+                    {
+                        m_strPlotTable, m_strCondTable, m_strTreeTable, m_strPopEvalTable, m_strPopStratumTable,
+                        m_strPpsaTable, m_strPopEstUnitTable, m_strSiteTreeTable, m_strBiosumPopStratumAdjustmentFactorsTable
+                    })
+                    {
+                        m_ado.m_strSQL = "UPDATE " + table + " SET biosum_status_cd = 1 WHERE biosum_status_cd = 9;";
+                        m_ado.SqlNonQuery(m_connTempMDBFile, m_ado.m_strSQL);
+                        if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
+                            frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile,
+                                m_ado.m_strSQL + "\r\n");
+                    }
+
+                    if (m_strTreeRegionalBiomassTable.Trim().Length > 0 &&
+                        m_ado.TableExist(m_connTempMDBFile, m_strTreeRegionalBiomassTable))
+                    {
+                        this.m_strSQL = " UPDATE " + this.m_strTreeRegionalBiomassTable +
+                                        " SET biosum_status_cd=1 WHERE biosum_status_cd = 9;";
                         this.m_ado.SqlNonQuery(this.m_connTempMDBFile, this.m_strSQL);
                     }
-                    this.m_strSQL = " UPDATE " + this.m_strPopStratumTable + " SET biosum_status_cd=1 WHERE biosum_status_cd = 9;";
-                    this.m_ado.SqlNonQuery(this.m_connTempMDBFile, this.m_strSQL);
-                    this.m_strSQL = " UPDATE " + this.m_strPpsaTable + " SET biosum_status_cd=1 WHERE biosum_status_cd = 9;";
-                    this.m_ado.SqlNonQuery(this.m_connTempMDBFile, this.m_strSQL);
-                    this.m_strSQL = " UPDATE " + this.m_strPopEstUnitTable + " SET biosum_status_cd=1 WHERE biosum_status_cd = 9;";
-                    this.m_ado.SqlNonQuery(this.m_connTempMDBFile, this.m_strSQL);
-                    this.m_strSQL = " UPDATE " + this.m_strSiteTreeTable + " SET biosum_status_cd=1 WHERE biosum_status_cd = 9;";
-                    this.m_ado.SqlNonQuery(this.m_connTempMDBFile, this.m_strSQL);
-                    this.m_strSQL = " UPDATE " + this.m_strBiosumPopStratumAdjustmentFactorsTable + " SET biosum_status_cd=1 WHERE biosum_status_cd = 9;";
-                    this.m_ado.SqlNonQuery(this.m_connTempMDBFile, this.m_strSQL);
+
+                    if (Checked(chkDwmImport))
+                    {
+                        foreach (string table in new string[]
+                        {
+                            m_strDwmCwdTable, m_strDwmFwdTable, m_strDwmDuffLitterTable, m_strDwmTransectSegmentTable
+                        })
+                        {
+                            m_ado.m_strSQL = "UPDATE " + table +
+                                             " SET biosum_status_cd = 1 WHERE biosum_status_cd = 9;";
+                            m_ado.SqlNonQuery(m_connTempMDBFile, m_ado.m_strSQL);
+                            if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
+                                frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile,
+                                    m_ado.m_strSQL + "\r\n");
+                        }
+                    }
 
                     SetThermValue(m_frmTherm.progressBar1, "Value", GetThermValue(m_frmTherm.progressBar1, "Maximum"));
                     SetThermValue(m_frmTherm.progressBar2, "Value", GetThermValue(m_frmTherm.progressBar2, "Maximum"));
                     frmMain.g_oDelegate.GetControlPropertyValue((System.Windows.Forms.Button)m_frmTherm.btnCancel, "Visible", false);
 
+                    string strMessage = "Successfully Appended\n" +
+                        m_intAddedPlotRows.ToString().Trim() + " Plots\n" +
+                        m_intAddedCondRows.ToString().Trim() + " Conditions \n" +
+                        m_intAddedTreeRows.ToString().Trim() + " Trees\n" +
+                        m_intAddedTreeRegionalBiomassRows.ToString().Trim() + " Tree Biomasses\n" +
+                        m_intAddedSiteTreeRows.ToString().Trim() + " Site Trees";
 
-                    MessageBox.Show("Successfully Appended \n" +
-                        m_intAddedPlotRows.ToString().Trim() + " Plot Records \n" +
-                        m_intAddedCondRows.ToString().Trim() + " Condition Records \n" +
-                        m_intAddedTreeRows.ToString().Trim() + " Tree Records \n" +
-                        m_intAddedTreeRegionalBiomassRows.ToString().Trim() + " Tree Regional Biomass Records \n" +
-                        m_intAddedSiteTreeRows.ToString().Trim() + " Site Tree Records", "Add Plot Data");
+                    if(Checked(chkDwmImport))
+                    {
+                        strMessage += "\r\n" +
+                            m_intAddedDwmTransectSegmentRows.ToString().Trim() + " Transect Segments\r\n" +
+                            m_intAddedDwmCwdRows.ToString().Trim() + " CWD Pieces\r\n" +
+                            m_intAddedDwmFwdRows.ToString().Trim() + " FWD Transects\r\n" +
+                            m_intAddedDwmDuffLitterRows.ToString().Trim() + " Duff and Litter Samples";
+                    }
+
+                    MessageBox.Show(strMessage, "Add Plot Data");
 
                     this.m_strLoadedPopEstUnitInputTable =
                         (string)frmMain.g_oDelegate.GetControlPropertyValue((System.Windows.Forms.ComboBox)cmbFiadbPopEstUnitTable, "Text", false);
@@ -2886,40 +2861,27 @@ namespace FIA_Biosum_Manager
                     this.m_strLoadedFiadbInputFile =
                         (string)frmMain.g_oDelegate.GetControlPropertyValue((System.Windows.Forms.TextBox)txtMDBFiadbInputFile, "Text", false);
                     System.Threading.Thread.Sleep(1000);
-
                 }
+
                 else
                 {
-                    //error occurred in the updatecolumns so delete the records
-                    this.m_strSQL = "DELETE FROM " + this.m_strPlotTable + " WHERE biosum_status_cd = 9;";
-                    this.m_ado.SqlNonQuery(this.m_connTempMDBFile, this.m_strSQL);
-                    //delete added cond records since error occured
-                    this.m_strSQL = "DELETE FROM " + this.m_strCondTable + " WHERE biosum_status_cd = 9;";
-                    this.m_ado.SqlNonQuery(this.m_connTempMDBFile, this.m_strSQL);
-                    //delete added cond records since error occured
-                    this.m_strSQL = "DELETE FROM " + this.m_strTreeTable + " WHERE biosum_status_cd = 9;";
-                    this.m_ado.SqlNonQuery(this.m_connTempMDBFile, this.m_strSQL);
-                    //delete added cond records since error occured
+                    //An ADO error occurred when updating columns so delete the records
+                    DeleteFromTablesWhereFilter(
+                        m_ado,
+                        new string[]
+                        {
+                            m_strPlotTable, m_strCondTable, m_strTreeTable, m_strPopEvalTable, m_strPopStratumTable,
+                            m_strPpsaTable, m_strPopEstUnitTable, m_strSiteTreeTable,
+                            m_strBiosumPopStratumAdjustmentFactorsTable, m_strDwmCwdTable, m_strDwmFwdTable,
+                            m_strDwmDuffLitterTable, m_strDwmTransectSegmentTable
+                        },
+                        " WHERE biosum_status_cd=9;");
                     if (m_strTreeRegionalBiomassTable.Trim().Length > 0 && m_ado.TableExist(m_connTempMDBFile, m_strTreeRegionalBiomassTable))
                     {
-                        this.m_strSQL = "DELETE FROM " + this.m_strTreeRegionalBiomassTable + " WHERE biosum_status_cd = 9;";
-                        this.m_ado.SqlNonQuery(this.m_connTempMDBFile, this.m_strSQL);
+                        DeleteFromTablesWhereFilter(m_ado, this.m_strTreeRegionalBiomassTable, " WHERE biosum_status_cd=9;");
                     }
-                    this.m_strSQL = "DELETE FROM " + this.m_strPopEvalTable + " WHERE biosum_status_cd = 9;";
-                    this.m_ado.SqlNonQuery(this.m_connTempMDBFile, this.m_strSQL);
-                    this.m_strSQL = "DELETE FROM " + this.m_strPopStratumTable + " WHERE biosum_status_cd = 9;";
-                    this.m_ado.SqlNonQuery(this.m_connTempMDBFile, this.m_strSQL);
-                    this.m_strSQL = "DELETE FROM " + this.m_strPpsaTable + " WHERE biosum_status_cd = 9;";
-                    this.m_ado.SqlNonQuery(this.m_connTempMDBFile, this.m_strSQL);
-                    this.m_strSQL = "DELETE FROM " + this.m_strPopEstUnitTable + " WHERE biosum_status_cd = 9;";
-                    this.m_ado.SqlNonQuery(this.m_connTempMDBFile, this.m_strSQL);
-                    this.m_strSQL = "DELETE FROM " + this.m_strSiteTreeTable + " WHERE biosum_status_cd = 9;";
-                    this.m_ado.SqlNonQuery(this.m_connTempMDBFile, this.m_strSQL);
-                    this.m_strSQL = "DELETE FROM " + this.m_strBiosumPopStratumAdjustmentFactorsTable + " WHERE biosum_status_cd = 9;";
-                    this.m_ado.SqlNonQuery(this.m_connTempMDBFile, this.m_strSQL);
                     MessageBox.Show("!!Error Occured Adding Plot Records: 0 Records Added!!", "Add Plot Data", System.Windows.Forms.MessageBoxButtons.OK, System.Windows.Forms.MessageBoxIcon.Exclamation);
                 }
-
 
                 this.m_connTempMDBFile.Close();
                 while (m_connTempMDBFile.State != System.Data.ConnectionState.Closed)
@@ -2931,9 +2893,7 @@ namespace FIA_Biosum_Manager
                 frmMain.g_oDelegate.SetControlPropertyValue((System.Windows.Forms.Form)ReferenceFormDialog, "Visible", true);
                 frmMain.g_oDelegate.SetControlPropertyValue((System.Windows.Forms.Form)ReferenceFormDialog, "Enabled", true);
 
-
                 LoadMDBPlotCondTreeData_Finish();
-
             }
             catch (System.Threading.ThreadInterruptedException err)
 			{
@@ -2961,7 +2921,6 @@ namespace FIA_Biosum_Manager
                 this.CancelThreadCleanup();
 			    this.ThreadCleanUp();
 				this.CleanupThread();
-				
 			}
 			catch (Exception err)
 			{
@@ -2976,49 +2935,163 @@ namespace FIA_Biosum_Manager
 			{
                
 			}
-			
-			if (this.m_connTempMDBFile != null)
-			{
+
+            if (this.m_connTempMDBFile != null)
+            {
                 if (m_connTempMDBFile.State != System.Data.ConnectionState.Closed)
                 {
                     m_ado.CloseConnection(m_connTempMDBFile);
                 }
                 m_connTempMDBFile = null;
-			}
-			if (m_ado != null)
-			{
-				if (m_ado.m_DataSet != null)
-				{
-					this.m_ado.m_DataSet.Clear();
-					this.m_ado.m_DataSet.Dispose();
-				}
-				this.m_ado = null;
-			}
+            }
+            if (m_ado != null)
+            {
+                if (m_ado.m_DataSet != null)
+                {
+                    this.m_ado.m_DataSet.Clear();
+                    this.m_ado.m_DataSet.Dispose();
+                }
+                this.m_ado = null;
+            }
             frmMain.g_oDelegate.SetControlPropertyValue((System.Windows.Forms.Form)ReferenceFormDialog, "Enabled", true);
 			if (this.m_frmTherm != null) frmMain.g_oDelegate.SetControlPropertyValue((System.Windows.Forms.Form)m_frmTherm,"Visible",false);
-
-            
-
-           
             LoadMDBPlotCondTreeData_Finish();
-
             CleanupThread();
-
             frmMain.g_oDelegate.m_oEventThreadStopped.Set();
             this.Invoke(frmMain.g_oDelegate.m_oDelegateThreadFinished);
-		
-		
-		
-
-		
-
-
 		}
 
-		
+
+	    /// <summary>
+	    /// Delete records from strTableName in the database p_ado is currently connected to using the strDeleteFilter.
+	    /// </summary>
+	    /// <param name="strTableName">The name of the table</param>
+	    /// <param name="strDeleteFilter">A WHERE clause for the delete query</param>
+	    private void DeleteFromTablesWhereFilter(ado_data_access p_ado, string strTableName, string strDeleteFilter)
+	    {
+	        p_ado.m_strSQL = "DELETE FROM " + strTableName + strDeleteFilter;
+	        p_ado.SqlNonQuery(m_connTempMDBFile, p_ado.m_strSQL);
+            if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
+                frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
+	    }
+
+	    /// <summary>
+	    /// Delete records from strTableNames in the database p_ado is currently connected to using the strDeleteFilter.
+	    /// </summary>
+	    /// <param name="strTableName">An array of table names to delete</param>
+	    /// <param name="strDeleteFilter">A WHERE clause for the delete query</param>
+	    private void DeleteFromTablesWhereFilter(ado_data_access p_ado, string[] strTableNames, string strDeleteFilter)
+	    {
+	        foreach (string table in strTableNames)
+	        {
+	            p_ado.m_strSQL = "DELETE FROM " + table + strDeleteFilter;
+	            p_ado.SqlNonQuery(m_connTempMDBFile, p_ado.m_strSQL);
+                if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
+                    frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
+	        }
+	    }
+
+	    /// <summary>
+	    /// After importing DWM table data from FIADB to Master.mdb, join the DWM table with the plot/cond tables to get the BSCID
+	    /// </summary>
+	    /// <param name="p_ado">Reference to the temporary database used to link FIADB and Master during plot input phase</param>
+	    /// <param name="strDestTable">The DWM table to update</param>
+	    private void UpdateDwmBiosumCondIds(ado_data_access p_ado, string strDestTable = null)
+	    {
+	        p_ado.m_strSQL = String.Format(
+	            "UPDATE {0} t INNER JOIN ({1} p INNER JOIN {2} c ON c.biosum_plot_id = p.biosum_plot_id) ON (p.cn = t.plt_cn) AND (t.CONDID = c.condid) " +
+	            "SET t.biosum_cond_id=c.biosum_cond_id WHERE t.biosum_cond_id='9999999999999999999999999' AND p.biosum_status_cd=9;",
+	            strDestTable, m_strPlotTable, m_strCondTable);
+	        p_ado.SqlNonQuery(m_connTempMDBFile, p_ado.m_strSQL);
+	        m_intError = p_ado.m_intError;
+
+            if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
+                frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
+	    }
+        
+	    /// <summary>
+	    /// Creates temporary DWM table from FIADB that associates dwm data with a biosum_cond_id. 
+	    /// Assumes that the FIADB DWM table has a plt_cn and condid.
+	    /// </summary>
+	    /// <param name="strSourceTable"></param>
+	    /// <param name="strTempTable"></param>
+	    private void SelectIntoTempDWMTableFromSourceDWMTable(ado_data_access p_ado, string strSourceTable = null, string strTempTable = null)
+	    {
+	        p_ado.m_strSQL = String.Format(
+	            "SELECT TRIM(c.biosum_cond_id) AS biosum_cond_id, 9 as biosum_status_cd, t.* INTO {0} " +
+	            "FROM {1} t INNER JOIN ({2} p INNER JOIN {3} c ON c.biosum_plot_id = p.biosum_plot_id) ON (p.cn = t.plt_cn) AND (t.CONDID = c.condid) " +
+	            "WHERE p.biosum_status_cd=9;", strTempTable, strSourceTable, m_strPlotTable, m_strCondTable);
+	        p_ado.SqlNonQuery(m_connTempMDBFile, p_ado.m_strSQL);
+	        m_intError = p_ado.m_intError;
+
+            if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
+                frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
+	    }
+
+        /// <summary>
+        /// Generates and executes an SQL "INSERT INTO dest_tablename (columns) SELECT columns FROM source_tablename" statement
+        /// strInsertFields contains a subset of the source table columns that are common with the dest table.
+        /// </summary>
+        /// <param name="strSourceTable"></param>
+        /// <param name="strDestTable"></param>
+        /// <param name="strInsertFields"></param>
+        private void InsertIntoDestTableFromSourceTable(ado_data_access p_ado, 
+            string strSourceTable = null, string strDestTable = null,
+            string strSourceFields = null, string strDestFields = null,
+            bool InsertBiosumCondIdAndStatusCode = false)
+        {
+            string strInsertIntoValues = "INSERT INTO {0} ({1}) ";
+            string strSelectColumns = "SELECT {2} FROM {3} dwm INNER JOIN {4} p ON dwm.plt_cn=p.cn;";
+            if (InsertBiosumCondIdAndStatusCode)
+            {
+                strInsertIntoValues = "INSERT INTO {0} (biosum_cond_id, biosum_status_cd, {1}) ";
+                strSelectColumns =
+                    "SELECT '9999999999999999999999999' AS biosum_cond_id, 9 AS biosum_status_cd, {2} FROM {3} dwm INNER JOIN {4} p ON dwm.plt_cn=p.cn;";
+            }
+            p_ado.m_strSQL = String.Format(strInsertIntoValues + strSelectColumns, 
+                strDestTable, strDestFields, strSourceFields, strSourceTable, m_strPlotTable);
+            if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
+                frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
+            p_ado.SqlNonQuery(m_connTempMDBFile, p_ado.m_strSQL);
+            m_intError = p_ado.m_intError;
+        }
+
+	    private string CreateStrFieldsFromDataTables(DataTable dtSourceSchema=null, DataTable dtDestSchema=null, string strTablePrefix="")
+	    {
+	        string strFields;
+	        int x;
+	        string strCol;
+	        int y;
+	        strFields = "";
+	        for (x = 0; x <= dtDestSchema.Rows.Count - 1; x++)
+	        {
+	            strCol = dtDestSchema.Rows[x]["columnname"].ToString().Trim();
+	            //see if there is an equivalent FIADB column
+	            for (y = 0; y <= dtSourceSchema.Rows.Count - 1; y++)
+	            {
+	                if (strCol.Trim().ToUpper() == dtSourceSchema.Rows[y]["columnname"].ToString().ToUpper())
+	                {
+                        if (strCol=="VALUE")
+                        {
+                            strCol = strTablePrefix + "`" + strCol + "`";
+                        }
+	                    if (strFields.Trim().Length == 0)
+	                    {
+	                        strFields = strTablePrefix + strCol;
+	                    }
+	                    else
+	                    {
+	                        strFields += "," + strTablePrefix + strCol;
+	                    }
+	                    break;
+	                }
+	            }
+	        }
+	        return strFields;
+	    }
 
 
-		private void UpdateColumns(FIA_Biosum_Manager.ado_data_access p_ado)
+	    private void UpdateColumns(FIA_Biosum_Manager.ado_data_access p_ado)
 		{
             if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 1)
             {
@@ -3060,7 +3133,7 @@ namespace FIA_Biosum_Manager
 														 "c.condprop_unadj/ps.pmh_micr,0)))";
 
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 					p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 
                     SetLabelValue(m_frmTherm.lblMsg,"Text","Updating Condition Acres Column...Stand By");
@@ -3077,7 +3150,7 @@ namespace FIA_Biosum_Manager
 									 "SET acres = IIF( c.condprop IS NOT NULL and ps.expns IS NOT NULL," + 
 													"c.condprop * ps.expns,0)";
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 					p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 
                     //update condprop_specific column for when plot.macro_breakpoint_dia has a value
@@ -3101,7 +3174,7 @@ namespace FIA_Biosum_Manager
                                             "c.macrprop_unadj))) " + 
                                         "WHERE t.biosum_status_cd=9";
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
                     p_ado.SqlNonQuery(this.m_connTempMDBFile, p_ado.m_strSQL);
                     //check if null values 
                     p_ado.m_strSQL = "SELECT COUNT(*) AS ROWCOUNT " +
@@ -3112,7 +3185,7 @@ namespace FIA_Biosum_Manager
                                            "t.statecd = bp.statecd AND " +
                                            "t.unitcd = bp.unitcd";
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
                     //check if condprop_specific null and exists in the tree macro plot breakpoint diameter table
                     if ((double)p_ado.getSingleDoubleValueFromSQLQuery(m_connTempMDBFile, p_ado.m_strSQL, "temp") > 0)
                     {
@@ -3135,7 +3208,7 @@ namespace FIA_Biosum_Manager
                                                 "c.macrprop_unadj))) " +
                                          "WHERE t.biosum_status_cd=9";
                         if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                            frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                            frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
                         p_ado.SqlNonQuery(this.m_connTempMDBFile, p_ado.m_strSQL);
                     }
                     else
@@ -3148,7 +3221,7 @@ namespace FIA_Biosum_Manager
                                                     "WHERE t.statecd=bp.statecd AND t.unitcd=bp.unitcd)) b " + 
                                          "WHERE a.CN=b.CN AND a.condprop_specific IS NULL AND a.biosum_status_cd=9";
                         if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                            frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                            frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
                         //handle for those states and units that do not have macro plot
                         if ((double)p_ado.getSingleDoubleValueFromSQLQuery(m_connTempMDBFile, p_ado.m_strSQL, "temp") > 0)
                         {
@@ -3163,7 +3236,7 @@ namespace FIA_Biosum_Manager
                                                 "c.subpprop_unadj)) " +
                                              "WHERE t.biosum_status_cd=9";
                             if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                                frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                                frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
                             p_ado.SqlNonQuery(this.m_connTempMDBFile, p_ado.m_strSQL);
 
                         }
@@ -3173,8 +3246,8 @@ namespace FIA_Biosum_Manager
             		//Update fvs_tree_id column for tracking a tree between BioSum and FVS for lifetime of project
             		SetLabelValue(m_frmTherm.lblMsg, "Text", "Updating Tree fvs_tree_id Column...Stand By");
             		frmMain.g_oDelegate.ExecuteControlMethod((System.Windows.Forms.Control) this.m_frmTherm, "Refresh");
-            		m_ado.m_strSQL = "UPDATE " + this.m_strTreeTable + " SET fvs_tree_id = CStr(subp*1000+tree);";
-            		this.m_ado.SqlNonQuery(this.m_connTempMDBFile, this.m_ado.m_strSQL);
+            		p_ado.m_strSQL = "UPDATE " + this.m_strTreeTable + " SET fvs_tree_id = CStr(subp*1000+tree);";
+            		this.m_ado.SqlNonQuery(this.m_connTempMDBFile, p_ado.m_strSQL);
 
                     SetLabelValue(m_frmTherm.lblMsg,"Text","Updating Tree tpacurr Column...Stand By");
                     frmMain.g_oDelegate.ExecuteControlMethod((System.Windows.Forms.Control)this.m_frmTherm, "Refresh");
@@ -3207,7 +3280,7 @@ namespace FIA_Biosum_Manager
                             "SET drybiom = IIF(drb.regional_drybiom IS NOT NULL,drb.regional_drybiom,null)," +
                                 "drybiot = IIF(drb.regional_drybiot IS NOT NULL,drb.regional_drybiot,null)";
                         if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                            frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                            frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
                         p_ado.SqlNonQuery(this.m_connTempMDBFile, p_ado.m_strSQL);
                     }
                    
@@ -3220,7 +3293,6 @@ namespace FIA_Biosum_Manager
                         if (m_oOracleServices.m_oTree == null) MessageBox.Show("m_oTree==null");
                         m_oOracleServices.m_oTree.GetVolumesMode = FIADB.Oracle.Services.Tree.GetVolumesModeValues.SQLUpdate;
                         //if (m_strGridTableSource.Trim() != Tables.FVS.DefaultOracleInputVolumesTable)
-                        //{
                         //step 5 - delete and create work tables
                         if (p_ado.TableExist(this.m_connTempMDBFile, Tables.FVS.DefaultOracleInputVolumesTable))
                             p_ado.SqlNonQuery(this.m_connTempMDBFile, "DROP TABLE " + Tables.FVS.DefaultOracleInputVolumesTable);
@@ -3353,7 +3425,7 @@ namespace FIA_Biosum_Manager
 
 					strTime = System.DateTime.Now.ToString();
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 					p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 					strTime += " " + System.DateTime.Now.ToString();
 					//MessageBox.Show(strTime);
@@ -3368,7 +3440,7 @@ namespace FIA_Biosum_Manager
 
 					strTime = System.DateTime.Now.ToString();
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 					p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 					strTime += " " + System.DateTime.Now.ToString();
 					//MessageBox.Show(strTime);
@@ -3382,7 +3454,7 @@ namespace FIA_Biosum_Manager
 					//for softwood live trees >= 5 inches in diameter 
 					p_ado.m_strSQL = "DELETE FROM cond_column_updates_work_table;";
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 					p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 
 					p_ado.m_strSQL = "INSERT INTO cond_column_updates_work_table (biosum_cond_id,swd_tpacurr) " + 
@@ -3397,7 +3469,7 @@ namespace FIA_Biosum_Manager
 
 					strTime = System.DateTime.Now.ToString();
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 					p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 					strTime += " " + System.DateTime.Now.ToString();
 					//MessageBox.Show(strTime);
@@ -3412,7 +3484,7 @@ namespace FIA_Biosum_Manager
 
 					strTime = System.DateTime.Now.ToString();
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 					p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 					strTime += " " + System.DateTime.Now.ToString();
 					//MessageBox.Show(strTime);
@@ -3426,7 +3498,7 @@ namespace FIA_Biosum_Manager
 					//for hardwood live trees >= 5 inches in diameter 
 					p_ado.m_strSQL = "DELETE FROM cond_column_updates_work_table;";
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 					p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 
 					p_ado.m_strSQL = "INSERT INTO cond_column_updates_work_table (biosum_cond_id,hwd_tpacurr) " + 
@@ -3441,7 +3513,7 @@ namespace FIA_Biosum_Manager
 
 					strTime = System.DateTime.Now.ToString();
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 					p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 					strTime += " " + System.DateTime.Now.ToString();
 					//MessageBox.Show(strTime);
@@ -3456,7 +3528,7 @@ namespace FIA_Biosum_Manager
 
 					strTime = System.DateTime.Now.ToString();
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 					p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 					strTime += " " + System.DateTime.Now.ToString();
 					//MessageBox.Show(strTime);
@@ -3472,7 +3544,7 @@ namespace FIA_Biosum_Manager
 					//for all live trees >= 5 inches in diameter 
 					p_ado.m_strSQL = "DELETE FROM cond_column_updates_work_table;";
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 					p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 
 					p_ado.m_strSQL = "INSERT INTO cond_column_updates_work_table (biosum_cond_id,vol_ac_grs_ft3) " + 
@@ -3486,7 +3558,7 @@ namespace FIA_Biosum_Manager
 
 					strTime = System.DateTime.Now.ToString();
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 					p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 					strTime += " " + System.DateTime.Now.ToString();
 					//MessageBox.Show(strTime);
@@ -3501,7 +3573,7 @@ namespace FIA_Biosum_Manager
 
 					strTime = System.DateTime.Now.ToString();
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 					p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 					strTime += " " + System.DateTime.Now.ToString();
 					//MessageBox.Show(strTime);
@@ -3515,7 +3587,7 @@ namespace FIA_Biosum_Manager
 					//for all live hardwood trees >= 5 inches in diameter 
 					p_ado.m_strSQL = "DELETE FROM cond_column_updates_work_table;";
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 					p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 
 					p_ado.m_strSQL = "INSERT INTO cond_column_updates_work_table (biosum_cond_id,hwd_vol_ac_grs_ft3) " + 
@@ -3530,7 +3602,7 @@ namespace FIA_Biosum_Manager
 
 					strTime = System.DateTime.Now.ToString();
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 					p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 					strTime += " " + System.DateTime.Now.ToString();
 					//MessageBox.Show(strTime);
@@ -3545,7 +3617,7 @@ namespace FIA_Biosum_Manager
 
 					strTime = System.DateTime.Now.ToString();
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 					p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 					strTime += " " + System.DateTime.Now.ToString();
 					//MessageBox.Show(strTime);
@@ -3561,7 +3633,7 @@ namespace FIA_Biosum_Manager
 					//for all live softwood trees >= 5 inches in diameter 
 					p_ado.m_strSQL = "DELETE FROM cond_column_updates_work_table;";
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 					p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 
 					p_ado.m_strSQL = "INSERT INTO cond_column_updates_work_table (biosum_cond_id,swd_vol_ac_grs_ft3) " + 
@@ -3576,7 +3648,7 @@ namespace FIA_Biosum_Manager
 
 					strTime = System.DateTime.Now.ToString();
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 					p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 					strTime += " " + System.DateTime.Now.ToString();
 					//MessageBox.Show(strTime);
@@ -3591,7 +3663,7 @@ namespace FIA_Biosum_Manager
 
 					strTime = System.DateTime.Now.ToString();
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 					p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 					strTime += " " + System.DateTime.Now.ToString();
 					//MessageBox.Show(strTime);
@@ -3603,7 +3675,7 @@ namespace FIA_Biosum_Manager
 					//ba_ft2_ac basal area column
 					p_ado.m_strSQL = "DELETE FROM cond_column_updates_work_table;";
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 					p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 
 					p_ado.m_strSQL = "INSERT INTO cond_column_updates_work_table (biosum_cond_id,ba_ft2_ac) " + 
@@ -3618,7 +3690,7 @@ namespace FIA_Biosum_Manager
 
 					strTime = System.DateTime.Now.ToString();
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 					p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 					strTime += " " + System.DateTime.Now.ToString();
 					//MessageBox.Show(strTime);
@@ -3633,7 +3705,7 @@ namespace FIA_Biosum_Manager
 
 					strTime = System.DateTime.Now.ToString();
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 					p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 					strTime += " " + System.DateTime.Now.ToString();
 					//MessageBox.Show(strTime);
@@ -3645,7 +3717,7 @@ namespace FIA_Biosum_Manager
 					//swd_ba_ft2_ac softwood basal area 
 					p_ado.m_strSQL = "DELETE FROM cond_column_updates_work_table;";
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 					p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 
 					p_ado.m_strSQL = "INSERT INTO cond_column_updates_work_table (biosum_cond_id,swd_ba_ft2_ac) " + 
@@ -3661,7 +3733,7 @@ namespace FIA_Biosum_Manager
 
 					strTime = System.DateTime.Now.ToString();
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 					p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 					strTime += " " + System.DateTime.Now.ToString();
 					//MessageBox.Show(strTime);
@@ -3676,7 +3748,7 @@ namespace FIA_Biosum_Manager
 
 					strTime = System.DateTime.Now.ToString();
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 					p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 					strTime += " " + System.DateTime.Now.ToString();
 					//MessageBox.Show(strTime);
@@ -3687,7 +3759,7 @@ namespace FIA_Biosum_Manager
 					//hardwood ba_ft2_ac
 					p_ado.m_strSQL = "DELETE FROM cond_column_updates_work_table;";
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 					p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 
 					p_ado.m_strSQL = "INSERT INTO cond_column_updates_work_table (biosum_cond_id,hwd_ba_ft2_ac) " + 
@@ -3702,7 +3774,7 @@ namespace FIA_Biosum_Manager
 
 					strTime = System.DateTime.Now.ToString();
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 					p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 					strTime += " " + System.DateTime.Now.ToString();
 					//MessageBox.Show(strTime);
@@ -3717,7 +3789,7 @@ namespace FIA_Biosum_Manager
 
 					strTime = System.DateTime.Now.ToString();
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 					p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 					strTime += " " + System.DateTime.Now.ToString();
 					//MessageBox.Show(strTime);
@@ -3730,7 +3802,7 @@ namespace FIA_Biosum_Manager
 				{
 					p_ado.m_strSQL = "DELETE FROM cond_column_updates_work_table;";
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 					p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 
 					p_ado.m_strSQL = "INSERT INTO cond_column_updates_work_table (biosum_cond_id,volcsgrs) " + 
@@ -3744,7 +3816,7 @@ namespace FIA_Biosum_Manager
 
 					strTime = System.DateTime.Now.ToString();
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 					p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 					strTime += " " + System.DateTime.Now.ToString();
 					//MessageBox.Show(strTime);
@@ -3761,7 +3833,7 @@ namespace FIA_Biosum_Manager
 
 					strTime = System.DateTime.Now.ToString();
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 					p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 					strTime += " " + System.DateTime.Now.ToString();
 					//MessageBox.Show(strTime);
@@ -3776,7 +3848,7 @@ namespace FIA_Biosum_Manager
 
 					p_ado.m_strSQL = "DELETE FROM cond_column_updates_work_table;";
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 					p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 
 					p_ado.m_strSQL = "INSERT INTO cond_column_updates_work_table (biosum_cond_id,swd_volcsgrs) " + 
@@ -3791,7 +3863,7 @@ namespace FIA_Biosum_Manager
 
 					strTime = System.DateTime.Now.ToString();
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 					p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 					strTime += " " + System.DateTime.Now.ToString();
 					//MessageBox.Show(strTime);
@@ -3808,7 +3880,7 @@ namespace FIA_Biosum_Manager
 
 					strTime = System.DateTime.Now.ToString();
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 					p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 					strTime += " " + System.DateTime.Now.ToString();
 					//MessageBox.Show(strTime);
@@ -3821,7 +3893,7 @@ namespace FIA_Biosum_Manager
 
 					p_ado.m_strSQL = "DELETE FROM cond_column_updates_work_table;";
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 					p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 
 					p_ado.m_strSQL = "INSERT INTO cond_column_updates_work_table (biosum_cond_id,hwd_volcsgrs) " + 
@@ -3836,7 +3908,7 @@ namespace FIA_Biosum_Manager
 
 					strTime = System.DateTime.Now.ToString();
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 					p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 					strTime += " " + System.DateTime.Now.ToString();
 					//MessageBox.Show(strTime);
@@ -3852,7 +3924,7 @@ namespace FIA_Biosum_Manager
 
 					strTime = System.DateTime.Now.ToString();
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 					p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 					strTime += " " + System.DateTime.Now.ToString();
 					//MessageBox.Show(strTime);
@@ -3872,7 +3944,7 @@ namespace FIA_Biosum_Manager
 				{
 					p_ado.m_strSQL = "DELETE FROM cond_column_updates_work_table;";
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 					p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 
 					p_ado.m_strSQL = "INSERT INTO cond_column_updates_work_table (biosum_cond_id,qmd_tot_cm) " + 
@@ -3886,7 +3958,7 @@ namespace FIA_Biosum_Manager
 
 					strTime = System.DateTime.Now.ToString();
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 					p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 					strTime += " " + System.DateTime.Now.ToString();
 					//MessageBox.Show(strTime);
@@ -3903,7 +3975,7 @@ namespace FIA_Biosum_Manager
 
 					strTime = System.DateTime.Now.ToString();
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 					p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 					strTime += " " + System.DateTime.Now.ToString();
 					//MessageBox.Show(strTime);
@@ -3918,7 +3990,7 @@ namespace FIA_Biosum_Manager
 
 					p_ado.m_strSQL = "DELETE FROM cond_column_updates_work_table;";
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 					p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 
 					p_ado.m_strSQL = "INSERT INTO cond_column_updates_work_table (biosum_cond_id,swd_qmd_tot_cm) " + 
@@ -3932,7 +4004,7 @@ namespace FIA_Biosum_Manager
 
 					strTime = System.DateTime.Now.ToString();
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 					p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 					strTime += " " + System.DateTime.Now.ToString();
 					//MessageBox.Show(strTime);
@@ -3949,7 +4021,7 @@ namespace FIA_Biosum_Manager
 
 					strTime = System.DateTime.Now.ToString();
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 					p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 					strTime += " " + System.DateTime.Now.ToString();
 					//MessageBox.Show(strTime);
@@ -3962,7 +4034,7 @@ namespace FIA_Biosum_Manager
 
 					p_ado.m_strSQL = "DELETE FROM cond_column_updates_work_table;";
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 					p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 
 					p_ado.m_strSQL = "INSERT INTO cond_column_updates_work_table (biosum_cond_id,hwd_qmd_tot_cm) " + 
@@ -3976,7 +4048,7 @@ namespace FIA_Biosum_Manager
 
 					strTime = System.DateTime.Now.ToString();
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 					p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 					strTime += " " + System.DateTime.Now.ToString();
 					//MessageBox.Show(strTime);
@@ -3992,7 +4064,7 @@ namespace FIA_Biosum_Manager
 
 					strTime = System.DateTime.Now.ToString();
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 					p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 					strTime += " " + System.DateTime.Now.ToString();
 					//MessageBox.Show(strTime);
@@ -4007,7 +4079,7 @@ namespace FIA_Biosum_Manager
 				{
 					p_ado.m_strSQL = "DELETE FROM cond_column_updates_work_table;";
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 					p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 
 
@@ -4024,7 +4096,7 @@ namespace FIA_Biosum_Manager
 
 					strTime = System.DateTime.Now.ToString();
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 					p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 					strTime += " " + System.DateTime.Now.ToString();
 					//MessageBox.Show(strTime);
@@ -4041,7 +4113,7 @@ namespace FIA_Biosum_Manager
 
 					strTime = System.DateTime.Now.ToString();
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 					p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 					strTime += " " + System.DateTime.Now.ToString();
 					//MessageBox.Show(strTime);
@@ -4056,7 +4128,7 @@ namespace FIA_Biosum_Manager
 
 					p_ado.m_strSQL = "DELETE FROM cond_column_updates_work_table;";
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 					p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 
 					p_ado.m_strSQL = "INSERT INTO cond_column_updates_work_table (biosum_cond_id,hwd_vol_ac_grs_stem_ttl_ft3) " + 
@@ -4072,7 +4144,7 @@ namespace FIA_Biosum_Manager
 
 					strTime = System.DateTime.Now.ToString();
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 					p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 					strTime += " " + System.DateTime.Now.ToString();
 					//MessageBox.Show(strTime);
@@ -4089,7 +4161,7 @@ namespace FIA_Biosum_Manager
 
 					strTime = System.DateTime.Now.ToString();
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 					p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 					strTime += " " + System.DateTime.Now.ToString();
 					//MessageBox.Show(strTime);
@@ -4102,7 +4174,7 @@ namespace FIA_Biosum_Manager
 
 					p_ado.m_strSQL = "DELETE FROM cond_column_updates_work_table;";
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 					p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 
 					p_ado.m_strSQL = "INSERT INTO cond_column_updates_work_table (biosum_cond_id,swd_vol_ac_grs_stem_ttl_ft3) " + 
@@ -4118,7 +4190,7 @@ namespace FIA_Biosum_Manager
 
 					strTime = System.DateTime.Now.ToString();
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 					p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 					strTime += " " + System.DateTime.Now.ToString();
 					//MessageBox.Show(strTime);
@@ -4134,7 +4206,7 @@ namespace FIA_Biosum_Manager
 
 					strTime = System.DateTime.Now.ToString();
                     if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                        frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 					p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 					strTime += " " + System.DateTime.Now.ToString();
 					//MessageBox.Show(strTime);
@@ -4163,7 +4235,7 @@ namespace FIA_Biosum_Manager
 
 				strTime = System.DateTime.Now.ToString();
                 if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                    frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                    frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 				p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 				strTime += " " + System.DateTime.Now.ToString();
 				//MessageBox.Show(strTime);
@@ -4181,7 +4253,7 @@ namespace FIA_Biosum_Manager
 				//use the biosum_plot_input as our work table so delete all records
 				p_ado.m_strSQL = "DELETE FROM plot_column_updates_work_table ";
                 if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                    frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                    frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 				p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 
 				//insert the condition counts into the work table
@@ -4190,7 +4262,7 @@ namespace FIA_Biosum_Manager
 					" FROM " + this.m_strCondTable + 
 					" GROUP BY biosum_plot_id;";
                 if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                    frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                    frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 				p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 			}
             SetThermValue(m_frmTherm.progressBar1, "Value", 2);
@@ -4203,26 +4275,157 @@ namespace FIA_Biosum_Manager
 					"ON  p.biosum_plot_id = i.biosum_plot_id " + 
 					"SET p.num_cond = i.cond_ttl, p.one_cond_yn = IIF(i.cond_ttl > 1,'N','Y');";
                 if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 2)
-                    frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, m_ado.m_strSQL + "\r\n");
+                    frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, p_ado.m_strSQL + "\r\n");
 				p_ado.SqlNonQuery(this.m_connTempMDBFile,p_ado.m_strSQL);
 			}
             SetThermValue(m_frmTherm.progressBar1, "Value", 3);
 
 
-
-
-
-            this.m_intError=p_ado.m_intError;
-
-
-
-
-
-
-
-			//MessageBox.Show(strTime);
-			
 		}
+
+	    private void UpdateColumnsDownWoodyMaterials(ado_data_access p_ado)
+	    {
+            if (frmMain.g_bDebug && frmMain.g_intDebugLevel > 1)
+            {
+                frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, "\r\n//\r\n");
+                frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, "//uc_plot_input.UpdateColumnsDownWoodyMaterials\r\n");
+                frmMain.g_oUtils.WriteText(frmMain.g_oFrmMain.frmProject.uc_project1.m_strDebugFile, "//\r\n");
+            }
+
+
+            SetLabelValue(m_frmTherm.lblMsg,"Text","Importing DWM data...Stand By");
+            SetThermValue(m_frmTherm.progressBar1,"Maximum", 14);
+            SetThermValue(m_frmTherm.progressBar1, "Minimum", 0);
+            SetThermValue(m_frmTherm.progressBar1, "Value", 0);
+
+		    string strFIADBDbFile = "";
+		    strFIADBDbFile = (string) frmMain.g_oDelegate.GetControlPropertyValue((System.Windows.Forms.TextBox) txtMDBFiadbInputFile, "Text", false);
+		    strFIADBDbFile = strFIADBDbFile.Trim();
+		    String strFiaCWD = "fiadb_dwm_cwd_input";
+		    String strFiaFWD = "fiadb_dwm_fwd_input";
+		    String strFiaDL = "fiadb_dwm_dufflitter_input";
+		    String strFiaTS = "fiadb_dwm_transect_segment_input";
+
+		    p_ado.CloseConnection(m_connTempMDBFile);
+	        m_connTempMDBFile.Dispose();
+	        m_connTempMDBFile = null;
+
+		    dao_data_access p_dao = new dao_data_access();
+            //Link to FIADB source tables in temporary database
+		    p_dao.CreateTableLink(m_strTempMDBFile, strFiaCWD, strFIADBDbFile, m_strDwmCwdTable);
+		    p_dao.CreateTableLink(m_strTempMDBFile, strFiaFWD, strFIADBDbFile, m_strDwmFwdTable);
+		    p_dao.CreateTableLink(m_strTempMDBFile, strFiaDL, strFIADBDbFile, m_strDwmDuffLitterTable);
+		    p_dao.CreateTableLink(m_strTempMDBFile, strFiaTS, strFIADBDbFile, m_strDwmTransectSegmentTable);
+
+            //Link to Master_AUX.accdb DWM source tables in temporary database
+	        string strMasterAuxDb = frmMain.g_oFrmMain.frmProject.uc_project1.txtRootDirectory.Text.Trim() + "\\db\\master_aux.accdb"; 
+		    p_dao.CreateTableLink(m_strTempMDBFile, m_strDwmCwdTable, strMasterAuxDb, m_strDwmCwdTable);
+		    p_dao.CreateTableLink(m_strTempMDBFile, m_strDwmFwdTable, strMasterAuxDb, m_strDwmFwdTable);
+		    p_dao.CreateTableLink(m_strTempMDBFile, m_strDwmDuffLitterTable, strMasterAuxDb, m_strDwmDuffLitterTable);
+		    p_dao.CreateTableLink(m_strTempMDBFile, m_strDwmTransectSegmentTable, strMasterAuxDb, m_strDwmTransectSegmentTable);
+
+		    m_intError = p_dao.m_intError;
+		    p_dao.m_DaoWorkspace.Close();
+	        p_dao.m_DaoWorkspace = null;
+	        p_dao.m_DaoDbEngine = null;
+		    p_dao = null;
+
+            m_connTempMDBFile = new OleDbConnection(m_strTempMDBFileConn);
+	        m_connTempMDBFile.Open();
+
+            SetThermValue(m_frmTherm.progressBar1, "Value", 1);
+
+		    String strSourceFields = "";
+		    String strDestFields = "";
+		    String strSourceTableLink = "";
+		    System.Data.DataTable dtDwmCwd = p_ado.getTableSchema(m_connTempMDBFile, "select * from " + m_strDwmCwdTable);
+		    System.Data.DataTable dtDwmFwd = p_ado.getTableSchema(m_connTempMDBFile, "select * from " + m_strDwmFwdTable);
+		    System.Data.DataTable dtDwmDuffLitter = p_ado.getTableSchema(m_connTempMDBFile, "select * from " + m_strDwmDuffLitterTable);
+		    System.Data.DataTable dtDwmTransectSegment = p_ado.getTableSchema(m_connTempMDBFile, "select * from " + m_strDwmTransectSegmentTable);
+		    System.Data.DataTable dtFIADBDwmCwd = p_ado.getTableSchema(m_connTempMDBFile, "select * from " + strFiaCWD);
+		    System.Data.DataTable dtFIADBDwmFwd = p_ado.getTableSchema(m_connTempMDBFile, "select * from " + strFiaFWD);
+		    System.Data.DataTable dtFIADBDwmDuffLitter = p_ado.getTableSchema(m_connTempMDBFile, "select * from " + strFiaDL);
+		    System.Data.DataTable dtFIADBDwmTransectSegment = p_ado.getTableSchema(m_connTempMDBFile, "select * from " + strFiaTS);
+
+
+            //Preemptively remove any records that were not imported successfully 
+	        DeleteFromTablesWhereFilter(p_ado,
+	            new string[]
+	                {m_strDwmCwdTable, m_strDwmFwdTable, m_strDwmDuffLitterTable, m_strDwmTransectSegmentTable},
+	            " WHERE biosum_status_cd=9");
+
+	        //DWM Coarse Woody Debris FIADB into Master.MDB Table
+	        if (m_intError == 0 && !GetBooleanValue((System.Windows.Forms.Control) m_frmTherm, "AbortProcess"))
+	        {
+	            SetLabelValue(m_frmTherm.lblMsg, "Text", "Importing DWM CWD...Stand By");
+	            SetThermValue(m_frmTherm.progressBar1, "Value", 2);
+	            strDestFields = CreateStrFieldsFromDataTables(dtSourceSchema: dtFIADBDwmCwd, dtDestSchema: dtDwmCwd);
+	            strSourceFields = CreateStrFieldsFromDataTables(dtSourceSchema: dtFIADBDwmCwd, dtDestSchema: dtDwmCwd,
+	                strTablePrefix: "dwm.");
+	            InsertIntoDestTableFromSourceTable(p_ado, strSourceTable: strFiaCWD, strDestTable: m_strDwmCwdTable,
+	                strDestFields: strDestFields, strSourceFields: strSourceFields, InsertBiosumCondIdAndStatusCode: true);
+	            UpdateDwmBiosumCondIds(p_ado, m_strDwmCwdTable);
+	            m_intError = p_ado.m_intError;
+	        }
+
+	        //DWM Fine Woody Debris FIADB into Master.MDB Table
+	        if (m_intError == 0 && !GetBooleanValue((System.Windows.Forms.Control) m_frmTherm, "AbortProcess"))
+	        {
+	            SetLabelValue(m_frmTherm.lblMsg, "Text", "Importing DWM FWD...Stand By");
+	            SetThermValue(m_frmTherm.progressBar1, "Value", 4);
+	            strDestFields = CreateStrFieldsFromDataTables(dtSourceSchema: dtFIADBDwmFwd, dtDestSchema: dtDwmFwd);
+	            strSourceFields = CreateStrFieldsFromDataTables(dtSourceSchema: dtFIADBDwmFwd, dtDestSchema: dtDwmFwd,
+	                strTablePrefix: "dwm.");
+	            InsertIntoDestTableFromSourceTable(p_ado, strSourceTable: strFiaFWD, strDestTable: m_strDwmFwdTable,
+	                strDestFields: strDestFields, strSourceFields: strSourceFields, InsertBiosumCondIdAndStatusCode: true);
+	            UpdateDwmBiosumCondIds(p_ado, m_strDwmFwdTable);
+	            m_intError = p_ado.m_intError;
+	        }
+
+	        //DWM Duff Litter Fuel FIADB into Master.MDB Table
+	        if (m_intError == 0 && !GetBooleanValue((System.Windows.Forms.Control) m_frmTherm, "AbortProcess"))
+	        {
+	            SetLabelValue(m_frmTherm.lblMsg, "Text", "Importing DWM DuffLitter...Stand By");
+	            SetThermValue(m_frmTherm.progressBar1, "Value", 6);
+	            strDestFields = CreateStrFieldsFromDataTables(dtSourceSchema: dtFIADBDwmDuffLitter,
+	                dtDestSchema: dtDwmDuffLitter);
+	            strSourceFields = CreateStrFieldsFromDataTables(dtSourceSchema: dtFIADBDwmDuffLitter,
+	                dtDestSchema: dtDwmDuffLitter, strTablePrefix: "dwm.");
+	            InsertIntoDestTableFromSourceTable(p_ado, strSourceTable: strFiaDL,
+	                strDestTable: m_strDwmDuffLitterTable,
+	                strDestFields: strDestFields, strSourceFields: strSourceFields,
+	                InsertBiosumCondIdAndStatusCode: true);
+                p_ado.SqlNonQuery(m_connTempMDBFile,
+                    String.Format(
+                        "UPDATE {0} SET duffdep=0 WHERE duffdep IS NULL AND duff_nonsample_reasn_cd IS NULL;", //or other metacodes are null? dlf_sample_method, dl_status_cd, etc.
+                        m_strDwmDuffLitterTable));
+                p_ado.SqlNonQuery(m_connTempMDBFile,
+                    String.Format(
+                        "UPDATE {0} SET littdep=0 WHERE littdep IS NULL AND litter_nonsample_reasn_cd IS NULL;", //or other metacodes are null? dlf_sample_method, dl_status_cd, etc.
+                        m_strDwmDuffLitterTable));
+	            UpdateDwmBiosumCondIds(p_ado, m_strDwmDuffLitterTable);
+	            m_intError = p_ado.m_intError;
+	        }
+
+	        //DWM Transect Segment FIADB into Master.MDB Table
+	        if (m_intError == 0 && !GetBooleanValue((System.Windows.Forms.Control) m_frmTherm, "AbortProcess"))
+	        {
+	            SetLabelValue(m_frmTherm.lblMsg, "Text", "Importing DWM Transect Segment...Stand By");
+	            SetThermValue(m_frmTherm.progressBar1, "Value", 8);
+	            strDestFields = CreateStrFieldsFromDataTables(dtSourceSchema: dtFIADBDwmTransectSegment,
+	                dtDestSchema: dtDwmTransectSegment);
+	            strSourceFields = CreateStrFieldsFromDataTables(dtSourceSchema: dtFIADBDwmTransectSegment,
+	                dtDestSchema: dtDwmTransectSegment, strTablePrefix: "dwm.");
+	            InsertIntoDestTableFromSourceTable(p_ado, strSourceTable: strFiaTS,
+	                strDestTable: m_strDwmTransectSegmentTable,
+	                strDestFields: strDestFields, strSourceFields: strSourceFields, InsertBiosumCondIdAndStatusCode: true);
+	            UpdateDwmBiosumCondIds(p_ado, m_strDwmTransectSegmentTable);
+	            m_intError = p_ado.m_intError;
+	        }
+
+            SetLabelValue(m_frmTherm.lblMsg,"Text","");
+            SetThermValue(m_frmTherm.progressBar1, "Value", GetThermValue(m_frmTherm.progressBar1, "Maximum"));
+	    }
 	
 		private void ThermCancel(object sender, System.EventArgs e)
 		{

--- a/src/uc_project.cs
+++ b/src/uc_project.cs
@@ -899,7 +899,7 @@ namespace FIA_Biosum_Manager
 				p_frmTherm.Refresh();
 				p_frmTherm.progressBar1.Minimum = 1;
 				p_frmTherm.AbortProcess = false;
-				p_frmTherm.progressBar1.Maximum = 15;
+				p_frmTherm.progressBar1.Maximum = 16;
 				p_frmTherm.lblMsg.Text = strDestFile;
 				p_frmTherm.lblMsg.Visible=true;
 				p_frmTherm.lblMsg.Refresh();
@@ -964,7 +964,7 @@ namespace FIA_Biosum_Manager
 				//
 				//master file
 				//
-				//copy default master database to the new project directory
+				//copy default master database to the new project directory (not currently used)
 				strSourceFile = this.m_oEnv.strAppDir + "\\db\\master.mdb";
 				strDestFile = this.txtRootDirectory.Text.Trim() + "\\db\\master.mdb";
 				p_frmTherm.Increment(3);
@@ -1002,14 +1002,36 @@ namespace FIA_Biosum_Manager
 				frmMain.g_oTables.m_oProcessor.CreateTreeVolValSpeciesDiamGroupsTable(p_ado,p_ado.m_OleDbConnection,"tree_vol_val_by_species_diam_groups");
                 //biosum pop stratum adjustment factors table
                 frmMain.g_oTables.m_oFIAPlot.CreateBiosumPopStratumAdjustmentFactorsTable(p_ado, p_ado.m_OleDbConnection, frmMain.g_oTables.m_oFIAPlot.DefaultBiosumPopStratumAdjustmentFactorsTableName);
+
 				p_ado.CloseConnection(p_ado.m_OleDbConnection);
+
+                //
+                //master_aux file: Where additional input tables are stored
+                //
+				strDestFile = this.txtRootDirectory.Text.Trim() + "\\db\\master_aux.accdb";
+				p_frmTherm.Increment(4);
+				p_frmTherm.lblMsg.Text = strDestFile;
+				p_frmTherm.lblMsg.Refresh();
+				//System.IO.File.Copy(strSourceFile, strDestFile,true);	
+				p_dao.CreateMDB(strDestFile);
+				strConn = p_ado.getMDBConnString(strDestFile,"admin","");
+				p_ado.OpenConnection(strConn);
+                //DWM Section
+                frmMain.g_oTables.m_oFIAPlot.CreateDWMCoarseWoodyDebrisTable(p_ado, p_ado.m_OleDbConnection, frmMain.g_oTables.m_oFIAPlot.DefaultDWMCoarseWoodyDebrisName);
+                frmMain.g_oTables.m_oFIAPlot.CreateDWMFineWoodyDebrisTable(p_ado, p_ado.m_OleDbConnection, frmMain.g_oTables.m_oFIAPlot.DefaultDWMFineWoodyDebrisName);
+                frmMain.g_oTables.m_oFIAPlot.CreateDWMDuffLitterFuelTable(p_ado, p_ado.m_OleDbConnection, frmMain.g_oTables.m_oFIAPlot.DefaultDWMDuffLitterFuelName);
+                frmMain.g_oTables.m_oFIAPlot.CreateDWMTransectSegmentTable(p_ado, p_ado.m_OleDbConnection, frmMain.g_oTables.m_oFIAPlot.DefaultDWMTransectSegmentName);
+                //TODO: GRM Section
+
+				p_ado.CloseConnection(p_ado.m_OleDbConnection);
+
 				//
 				//fvsmaster file
 				//
 				//copy default fvsmaster database to the new project directory
 				strSourceFile = this.m_oEnv.strAppDir + "\\db\\fvsmaster.mdb";
 				strDestFile = this.txtRootDirectory.Text.Trim() + "\\db\\fvsmaster.mdb";
-				p_frmTherm.Increment(4);
+				p_frmTherm.Increment(5);
 				p_frmTherm.lblMsg.Text = strDestFile;
 				p_frmTherm.lblMsg.Refresh();
 				//System.IO.File.Copy(strSourceFile, strDestFile,true);	
@@ -1039,7 +1061,7 @@ namespace FIA_Biosum_Manager
 				//copy default master database to the new project directory
 				strSourceFile = this.m_oEnv.strAppDir + "\\db\\ref_master.mdb";
 				strDestFile = this.txtRootDirectory.Text.Trim() + "\\db\\ref_master.mdb";
-				p_frmTherm.Increment(5);
+				p_frmTherm.Increment(6);
 				p_frmTherm.lblMsg.Text = strDestFile;
 				p_frmTherm.lblMsg.Refresh();
 				System.IO.File.Copy(strSourceFile, strDestFile,true);
@@ -1056,21 +1078,21 @@ namespace FIA_Biosum_Manager
 				//copy default master database to the new project directory
 				strSourceFile = this.m_oEnv.strAppDir + "\\db\\ref_fvscommands.mdb";
 				strDestFile = this.txtRootDirectory.Text.Trim() + "\\db\\ref_fvscommands.mdb";
-				p_frmTherm.Increment(6);
+				p_frmTherm.Increment(7);
 				p_frmTherm.lblMsg.Text = strDestFile;
 				p_frmTherm.lblMsg.Refresh();
 				System.IO.File.Copy(strSourceFile, strDestFile,true);	
      			//
 				//core scenario rule definitions
 				//
-				p_frmTherm.Increment(7);
+				p_frmTherm.Increment(8);
 				p_frmTherm.lblMsg.Text = strDestFile;
 				p_frmTherm.lblMsg.Refresh();
 				CreateCoreScenarioRuleDefinitionDbAndTables(this.txtRootDirectory.Text.Trim() + "\\core\\db\\scenario_core_rule_definitions.mdb");
 				//copy default scenario_results database to the new project directory
 				strSourceFile = this.m_oEnv.strAppDir + "\\db\\scenario_results.mdb";
 				strDestFile = this.txtRootDirectory.Text.Trim() + "\\core\\db\\scenario_results.mdb";
-				p_frmTherm.Increment(8);
+				p_frmTherm.Increment(9);
 				p_frmTherm.lblMsg.Text = strDestFile;
 				p_frmTherm.lblMsg.Refresh();
 				System.IO.File.Copy(strSourceFile, strDestFile,true);		
@@ -1084,7 +1106,7 @@ namespace FIA_Biosum_Manager
 				CreateProcessorScenarioRunDbAndTables(this.txtRootDirectory.Text.Trim() + "\\processor\\db\\scenario_results.mdb");
 				//strSourceFile = this.m_oEnv.strAppDir + "\\db\\scenario_results.mdb";
 				//strDestFile = this.txtRootDirectory.Text.Trim() + "\\processor\\db\\scenario_results.mdb";
-				p_frmTherm.Increment(9);
+				p_frmTherm.Increment(10);
 				//p_frmTherm.lblMsg.Text = strDestFile;
 				p_frmTherm.lblMsg.Refresh();
 				//System.IO.File.Copy(strSourceFile, strDestFile,true);		
@@ -1092,14 +1114,14 @@ namespace FIA_Biosum_Manager
 				//copy default fvsin database to the new project directory
 				strSourceFile = this.m_oEnv.strAppDir + "\\db\\fvsin.mdb";
 				strDestFile = this.txtRootDirectory.Text.Trim() + "\\fvs\\db\\fvsin.mdb";
-				p_frmTherm.Increment(10);
+				p_frmTherm.Increment(11);
 				p_frmTherm.lblMsg.Text = strDestFile;
 				p_frmTherm.lblMsg.Refresh();
 				System.IO.File.Copy(strSourceFile, strDestFile,true);
 
 				strSourceFile = this.m_oEnv.strAppDir + "\\db\\fvsout.mdb";
 				strDestFile = this.txtRootDirectory.Text.Trim() + "\\fvs\\db\\fvsout.mdb";
-				p_frmTherm.Increment(11);
+				p_frmTherm.Increment(12);
 				p_frmTherm.lblMsg.Text = strDestFile;
 				p_frmTherm.lblMsg.Refresh();
 				System.IO.File.Copy(strSourceFile, strDestFile,true);
@@ -1107,7 +1129,7 @@ namespace FIA_Biosum_Manager
 				
 				strDestFile = this.txtRootDirectory.Text.Trim() + "\\processor\\db\\fvs_out_processor_in.mdb";
 				p_dao.CreateMDB(strDestFile);
-				p_frmTherm.Increment(12);
+				p_frmTherm.Increment(13);
 				p_frmTherm.lblMsg.Text = strDestFile;
 				p_frmTherm.lblMsg.Refresh();
 				strConn = p_ado.getMDBConnString(strDestFile,"admin","");
@@ -1129,7 +1151,7 @@ namespace FIA_Biosum_Manager
 
 				strSourceFile = this.m_oEnv.strAppDir + "\\db\\biosum_processor.mdb";
 				strDestFile = this.txtRootDirectory.Text.Trim() + "\\processor\\db\\biosum_processor.mdb";
-				p_frmTherm.Increment(13);
+				p_frmTherm.Increment(14);
 				p_frmTherm.lblMsg.Text = strDestFile;
 				p_frmTherm.lblMsg.Refresh();
 				System.IO.File.Copy(strSourceFile, strDestFile,true);
@@ -1502,7 +1524,6 @@ namespace FIA_Biosum_Manager
                              "'" + Tables.Reference.DefaultBiosumReferenceDbFile + "'," +
                              "'" + Tables.ProcessorScenarioRun.DefaultFiaTreeSpeciesRefTableName + "');";
                     p_ado.SqlNonQuery(p_ado.m_OleDbConnection, strSQL);
-
 
                     frmMain.g_oGeneralMacroSubstitutionVariable_Collection.Item(frmMain.PROJDIR).VariableSubstitutionString = this.txtRootDirectory.Text.Trim();
 					


### PR DESCRIPTION
Here is a concise summary of the changes involved with the issue #160 feature development:
- uc_project now stores DWM input data master_aux.accdb
- uc_plot_input supports DWM input optionally. also, some refactoring was done.
- uc_fvs_input UI adds a tab control to support configuring DWM and eventually GRM calibration data passed into FVSIn.accdb. 
  - Bug fixes: In the case of a datasource error when initializing fvs_input, AppendRecords terminates early. Cancelling the AppendRecords process works again (@lpotts).
- fvs_input supports both a crosswalk for converting dwm_fuelbed_typcd to an FVS numeric code, dwm fuel biomass calculations, and debug logging. The new FVS Location from the fiadb_fvs_variant table is used.
  - Bug fixes/refactoring: `using` syntax used for opening/closing OleDbConnections more frequently (with automatic dispose() calls), and FVSIN terminates more responsively when errors occur.
- Queries class now has DWM temporary tables and calculations.
  - Refactoring/cleanup: queries shortened, removal of unused columns, fields, comments, etc.
- bug fixes in datasource related to ado/dao resources not being released from @lpotts 
- uc_delete_conditions shows how many records were deleted with an optional log file, and also adopts `using` syntax for opening/closing connections